### PR TITLE
Remove score references from workflow steps

### DIFF
--- a/steps/step1_domain.py
+++ b/steps/step1_domain.py
@@ -17,7 +17,7 @@ from ..utils import direct_save_json_output, run_agent_with_retry
 logger = logging.getLogger(__name__)
 
 async def identify_domain(content: str, overall_trace_id: Optional[str] = None) -> Optional[DomainSchema]:
-    """Identify the primary domain (with confidence) from the input content.
+    """Identify the primary domain from the input content.
     
     Args:
         content: The text content to analyze
@@ -61,16 +61,14 @@ async def identify_domain(content: str, overall_trace_id: Optional[str] = None) 
 
         if domain_data and domain_data.domain:
             primary_domain = domain_data.domain.strip()
-            domain_confidence = domain_data.confidence_score
             if primary_domain:
-                logger.info(f"Step 1 Result: Primary Domain Identified = {primary_domain} (Confidence: {domain_confidence:.2f})")
-                print(f"Step 1 Result: Primary Domain Identified = {primary_domain} (Confidence: {domain_confidence:.2f})")
+                logger.info(f"Step 1 Result: Primary Domain Identified = {primary_domain}")
+                print(f"Step 1 Result: Primary Domain Identified = {primary_domain}")
 
-                logger.info("Saving primary domain identifier output (with confidence) to file...")
-                print("\nSaving primary domain output file (with confidence)...")
+                logger.info("Saving primary domain identifier output to file...")
+                print("\nSaving primary domain output file...")
                 domain_output_content: Dict[str, Any] = {
                     "identified_primary_domain": primary_domain,
-                    "confidence_score": domain_confidence,
                     "analysis_details": {
                         "source_text_length": len(content),
                         "model_used": DOMAIN_MODEL,

--- a/steps/step2_subdomain.py
+++ b/steps/step2_subdomain.py
@@ -17,7 +17,7 @@ from ..utils import direct_save_json_output, run_agent_with_retry
 logger = logging.getLogger(__name__)
 
 async def identify_subdomains(content: str, primary_domain: str, overall_trace_id: Optional[str] = None) -> Optional[SubDomainSchema]:
-    """Identify the sub-domains (with relevance scores) from the input content.
+    """Identify the sub-domains from the input content.
     
     Args:
         content: The text content to analyze
@@ -46,7 +46,7 @@ async def identify_subdomains(content: str, primary_domain: str, overall_trace_i
     sub_domain_data: Optional[SubDomainSchema] = None
 
     step2_input_list: List[TResponseInputItem] = [
-        {"role": "user", "content": f"The primary domain of the following text is '{primary_domain}'. Please identify the specific sub-domains within the text related to this primary domain, providing a relevance score (0.0-1.0) for each, and a brief analysis summary."},
+        {"role": "user", "content": f"The primary domain of the following text is '{primary_domain}'. Please identify the specific sub-domains within the text related to this primary domain and provide a brief analysis summary."},
         {"role": "user", "content": f"--- Full Text Start ---\n{content}\n--- Full Text End ---"}
     ]
 
@@ -83,15 +83,15 @@ async def identify_subdomains(content: str, primary_domain: str, overall_trace_i
                 elif not sub_domain_data.primary_domain:
                     sub_domain_data.primary_domain = primary_domain # Ensure primary domain is set
 
-                sub_domains_with_scores = sub_domain_data.identified_sub_domains
+                sub_domains_items = sub_domain_data.identified_sub_domains
                 sub_domains_list = [
-                    item.sub_domain.strip() for item in sub_domains_with_scores if item.sub_domain and item.sub_domain.strip()
+                    item.sub_domain.strip() for item in sub_domains_items if item.sub_domain and item.sub_domain.strip()
                 ]
 
-                log_items = [f"'{item.sub_domain}' (Score: {item.relevance_score:.2f})" for item in sub_domains_with_scores]
+                log_items = [f"'{item.sub_domain}'" for item in sub_domains_items]
                 logger.info(f"Step 2 Result: Identified Sub-Domains = [{', '.join(log_items)}]")
-                logger.info(f"Step 2 Result (Structured Sub-Domains with Scores):\n{sub_domain_data.model_dump_json(indent=2)}")
-                print("\n--- Sub-Domains Identified (Structured Output from Step 2 with Relevance) ---")
+                logger.info(f"Step 2 Result (Structured Sub-Domains):\n{sub_domain_data.model_dump_json(indent=2)}")
+                print("\n--- Sub-Domains Identified (Structured Output from Step 2) ---")
                 print(sub_domain_data.model_dump_json(indent=2))
 
                 if not sub_domains_list:
@@ -99,11 +99,11 @@ async def identify_subdomains(content: str, primary_domain: str, overall_trace_i
                     print("\nStep 2 completed, but no specific non-empty sub-domain names were identified. Cannot proceed further.")
                     sub_domain_data = None
                 else:
-                    logger.info("Saving sub-domain identifier output (with scores) to file...")
-                    print("\nSaving sub-domain output file (with scores)...")
+                    logger.info("Saving sub-domain identifier output to file...")
+                    print("\nSaving sub-domain output file...")
                     sub_domain_output_content = {
                         "primary_domain": sub_domain_data.primary_domain,
-                        "identified_sub_domains": [item.model_dump() for item in sub_domains_with_scores],
+                        "identified_sub_domains": [item.model_dump() for item in sub_domains_items],
                         "analysis_summary": sub_domain_data.analysis_summary,
                         "analysis_details": {
                             "source_text_length": len(content),

--- a/steps/step4a_entity_types.py
+++ b/steps/step4a_entity_types.py
@@ -23,7 +23,7 @@ async def identify_entity_types(
     topic_data: TopicSchema,
     overall_trace_id: Optional[str] = None
 ) -> Optional[EntityTypeSchema]:
-    """Identify entity types (with relevance scores) based on domain, sub-domains, and topics.
+    """Identify entity types based on domain, sub-domains, and topics.
     
     Args:
         content: The text content to analyze
@@ -74,7 +74,7 @@ async def identify_entity_types(
             f"Analyze the following text to identify key entity types (e.g., PERSON, ORGANIZATION, LOCATION, DATE, "
             f"MONEY, PRODUCT, EVENT, TECHNOLOGY, SCIENTIFIC_CONCEPT, ECONOMIC_INDICATOR). "
             f"Use the provided context:\n{context_summary_for_prompt}\n\n"
-            f"Identify entity types relevant to this overall context and provide a relevance score (0.0-1.0) for each. "
+            f"Identify entity types relevant to this overall context. "
             f"Output ONLY using the required EntityTypeSchema, including the primary_domain and analyzed_sub_domains list in the output."
         )},
         {"role": "user", "content": f"--- Full Text Start ---\n{content}\n--- Full Text End ---"}
@@ -114,15 +114,15 @@ async def identify_entity_types(
                     # entity_data.analyzed_sub_domains = [sd.sub_domain for sd in sub_domain_data.identified_sub_domains]
 
                 # Log and print results
-                entity_log_items = [f"{item.entity_type} (Score: {item.relevance_score:.2f})" for item in entity_data.identified_entities]
+                entity_log_items = [item.entity_type for item in entity_data.identified_entities]
                 logger.info(f"Step 4a Result: Identified Entity Types = [{', '.join(entity_log_items)}]")
-                logger.info(f"Step 4a Result (Structured Entities with Scores):\n{entity_data.model_dump_json(indent=2)}")
-                print("\n--- Entity Types Identified (Structured Output from Step 4a with Relevance) ---")
+                logger.info(f"Step 4a Result (Structured Entities):\n{entity_data.model_dump_json(indent=2)}")
+                print("\n--- Entity Types Identified (Structured Output from Step 4a) ---")
                 print(entity_data.model_dump_json(indent=2))
 
                 # Save results
-                logger.info("Saving entity type identifier output (with scores) to file...")
-                print("\nSaving entity type output file (with scores)...")
+                logger.info("Saving entity type identifier output to file...")
+                print("\nSaving entity type output file...")
                 entity_type_output_content = {
                     "primary_domain": entity_data.primary_domain,
                     "analyzed_sub_domains": entity_data.analyzed_sub_domains, # Use agent's output list

--- a/steps/step4b_ontology_types.py
+++ b/steps/step4b_ontology_types.py
@@ -23,7 +23,7 @@ async def identify_ontology_types(
     topic_data: TopicSchema,
     overall_trace_id: Optional[str] = None
 ) -> Optional[OntologyTypeSchema]:
-    """Identify ontology types (with relevance scores) based on domain, sub-domains, and topics.
+    """Identify ontology types based on domain, sub-domains, and topics.
     
     Args:
         content: The text content to analyze
@@ -72,7 +72,7 @@ async def identify_ontology_types(
             f"Analyze the following text to identify relevant ontology types or concepts, potentially referencing standard ontologies "
             f"(like Schema.org, FIBO, domain-specific ones) where applicable. "
             f"Use the provided context:\n{context_summary_for_prompt}\n\n"
-            f"Identify ontology types/concepts relevant to this overall context and provide a relevance score (0.0-1.0) for each. "
+            f"Identify ontology types/concepts relevant to this overall context. "
             f"Output ONLY using the required OntologyTypeSchema, including the primary_domain and analyzed_sub_domains list in the output."
         )},
         {"role": "user", "content": f"--- Full Text Start ---\n{content}\n--- Full Text End ---"}
@@ -110,15 +110,15 @@ async def identify_ontology_types(
                     logger.warning(f"Analyzed sub-domains in Step 4b output {ontology_data.analyzed_sub_domains} differs from Step 2 input { [sd.sub_domain for sd in sub_domain_data.identified_sub_domains]}. Using Step 4b's list.")
 
                 # Log and print results
-                ontology_log_items = [f"{item.ontology_type} (Score: {item.relevance_score:.2f})" for item in ontology_data.identified_ontology_types]
+                ontology_log_items = [item.ontology_type for item in ontology_data.identified_ontology_types]
                 logger.info(f"Step 4b Result: Identified Ontology Types = [{', '.join(ontology_log_items)}]")
-                logger.info(f"Step 4b Result (Structured Ontology Types with Scores):\n{ontology_data.model_dump_json(indent=2)}")
-                print("\n--- Ontology Types Identified (Structured Output from Step 4b with Relevance) ---")
+                logger.info(f"Step 4b Result (Structured Ontology Types):\n{ontology_data.model_dump_json(indent=2)}")
+                print("\n--- Ontology Types Identified (Structured Output from Step 4b) ---")
                 print(ontology_data.model_dump_json(indent=2))
 
                 # Save results
-                logger.info("Saving ontology type identifier output (with scores) to file...")
-                print("\nSaving ontology type output file (with scores)...")
+                logger.info("Saving ontology type identifier output to file...")
+                print("\nSaving ontology type output file...")
                 ontology_type_output_content = {
                     "primary_domain": ontology_data.primary_domain,
                     "analyzed_sub_domains": ontology_data.analyzed_sub_domains, # Use agent's output list

--- a/steps/step4c_event_types.py
+++ b/steps/step4c_event_types.py
@@ -23,7 +23,7 @@ async def identify_event_types(
     topic_data: TopicSchema,
     overall_trace_id: Optional[str] = None
 ) -> Optional[EventSchema]:
-    """Identify event types (with relevance scores) based on domain, sub-domains, and topics.
+    """Identify event types based on domain, sub-domains, and topics.
 
     Args:
         content: The text content to analyze
@@ -72,7 +72,7 @@ async def identify_event_types(
         {"role": "user", "content": (
             f"Analyze the following text to identify key EVENT types (e.g., Meeting, Acquisition, Conference, Product Launch, Election). "
             f"Focus only on event types. Use the provided context:\n{context_summary_for_prompt}\n\n"
-            f"Identify event types relevant to this overall context and provide a relevance score (0.0-1.0) for each. "
+            f"Identify event types relevant to this overall context. "
             f"Output ONLY using the required EventSchema, including the primary_domain and analyzed_sub_domains list in the output."
         )},
         {"role": "user", "content": f"--- Full Text Start ---\n{content}\n--- Full Text End ---"}
@@ -108,15 +108,15 @@ async def identify_event_types(
                     logger.warning(f"Analyzed sub-domains in Step 4c output {event_data.analyzed_sub_domains} differs from Step 2 input { [sd.sub_domain for sd in sub_domain_data.identified_sub_domains]}. Using Step 4c's list.")
 
                 # Log and print results
-                event_log_items = [f"{item.event_type} (Score: {item.relevance_score:.2f})" for item in event_data.identified_events]
+                event_log_items = [item.event_type for item in event_data.identified_events]
                 logger.info(f"Step 4c Result: Identified Event Types = [{', '.join(event_log_items)}]")
-                logger.info(f"Step 4c Result (Structured Events with Scores):\n{event_data.model_dump_json(indent=2)}")
-                print("\n--- Event Types Identified (Structured Output from Step 4c with Relevance) ---")
+                logger.info(f"Step 4c Result (Structured Events):\n{event_data.model_dump_json(indent=2)}")
+                print("\n--- Event Types Identified (Structured Output from Step 4c) ---")
                 print(event_data.model_dump_json(indent=2))
 
                 # Save results
-                logger.info("Saving event type identifier output (with scores) to file...")
-                print("\nSaving event type output file (with scores)...")
+                logger.info("Saving event type identifier output to file...")
+                print("\nSaving event type output file...")
                 event_type_output_content = {
                     "primary_domain": event_data.primary_domain,
                     "analyzed_sub_domains": event_data.analyzed_sub_domains,

--- a/steps/step4d_statement_types.py
+++ b/steps/step4d_statement_types.py
@@ -29,7 +29,7 @@ async def identify_statement_types(
     topic_data: TopicSchema,
     overall_trace_id: Optional[str] = None
 ) -> Optional[StatementTypeSchema]:
-    """Identify statement types (with relevance scores) based on domain, sub-domains, and topics.
+    """Identify statement types based on domain, sub-domains, and topics.
 
     Args:
         content: The text content to analyze
@@ -78,7 +78,7 @@ async def identify_statement_types(
         {"role": "user", "content": (
             f"Analyze the following text to identify key STATEMENT types (e.g., Fact, Claim, Opinion, Question, Instruction). "
             f"Use the provided context:\n{context_summary_for_prompt}\n\n"
-            f"Identify statement types relevant to this overall context and provide a relevance score (0.0-1.0) for each. "
+            f"Identify statement types relevant to this overall context. "
             f"Output ONLY using the required StatementTypeSchema, including the primary_domain and analyzed_sub_domains list in the output."
         )},
         {"role": "user", "content": f"--- Full Text Start ---\n{content}\n--- Full Text End ---"}
@@ -114,15 +114,15 @@ async def identify_statement_types(
                     logger.warning(f"Analyzed sub-domains in Step 4d output {statement_data.analyzed_sub_domains} differs from Step 2 input { [sd.sub_domain for sd in sub_domain_data.identified_sub_domains]}. Using Step 4d's list.")
 
                 # Log and print results
-                statement_log_items = [f"{item.statement_type} (Score: {item.relevance_score:.2f})" for item in statement_data.identified_statements]
+                statement_log_items = [item.statement_type for item in statement_data.identified_statements]
                 logger.info(f"Step 4d Result: Identified Statement Types = [{', '.join(statement_log_items)}]")
-                logger.info(f"Step 4d Result (Structured Statements with Scores):\n{statement_data.model_dump_json(indent=2)}")
-                print("\n--- Statement Types Identified (Structured Output from Step 4d with Relevance) ---")
+                logger.info(f"Step 4d Result (Structured Statements):\n{statement_data.model_dump_json(indent=2)}")
+                print("\n--- Statement Types Identified (Structured Output from Step 4d) ---")
                 print(statement_data.model_dump_json(indent=2))
 
                 # Save results
-                logger.info("Saving statement type identifier output (with scores) to file...")
-                print("\nSaving statement type output file (with scores)...")
+                logger.info("Saving statement type identifier output to file...")
+                print("\nSaving statement type output file...")
                 statement_type_output_content = {
                     "primary_domain": statement_data.primary_domain,
                     "analyzed_sub_domains": statement_data.analyzed_sub_domains,

--- a/steps/step4e_evidence_types.py
+++ b/steps/step4e_evidence_types.py
@@ -29,7 +29,7 @@ async def identify_evidence_types(
     topic_data: TopicSchema,
     overall_trace_id: Optional[str] = None
 ) -> Optional[EvidenceTypeSchema]:
-    """Identify evidence types (with relevance scores) based on domain, sub-domains, and topics.
+    """Identify evidence types based on domain, sub-domains, and topics.
 
     Args:
         content: The text content to analyze
@@ -78,7 +78,7 @@ async def identify_evidence_types(
         {"role": "user", "content": (
             f"Analyze the following text to identify key EVIDENCE types (e.g., Testimony, Document, Statistic, Anecdote, Expert Opinion). "
             f"Use the provided context:\n{context_summary_for_prompt}\n\n"
-            f"Identify evidence types relevant to this overall context and provide a relevance score (0.0-1.0) for each. "
+            f"Identify evidence types relevant to this overall context. "
             f"Output ONLY using the required EvidenceTypeSchema, including the primary_domain and analyzed_sub_domains list in the output."
         )},
         {"role": "user", "content": f"--- Full Text Start ---\n{content}\n--- Full Text End ---"}
@@ -114,15 +114,15 @@ async def identify_evidence_types(
                     logger.warning(f"Analyzed sub-domains in Step 4e output {evidence_data.analyzed_sub_domains} differs from Step 2 input { [sd.sub_domain for sd in sub_domain_data.identified_sub_domains]}. Using Step 4e's list.")
 
                 # Log and print results
-                evidence_log_items = [f"{item.evidence_type} (Score: {item.relevance_score:.2f})" for item in evidence_data.identified_evidence]
+                evidence_log_items = [item.evidence_type for item in evidence_data.identified_evidence]
                 logger.info(f"Step 4e Result: Identified Evidence Types = [{', '.join(evidence_log_items)}]")
-                logger.info(f"Step 4e Result (Structured Evidence with Scores):\n{evidence_data.model_dump_json(indent=2)}")
-                print("\n--- Evidence Types Identified (Structured Output from Step 4e with Relevance) ---")
+                logger.info(f"Step 4e Result (Structured Evidence):\n{evidence_data.model_dump_json(indent=2)}")
+                print("\n--- Evidence Types Identified (Structured Output from Step 4e) ---")
                 print(evidence_data.model_dump_json(indent=2))
 
                 # Save results
-                logger.info("Saving evidence type identifier output (with scores) to file...")
-                print("\nSaving evidence type output file (with scores)...")
+                logger.info("Saving evidence type identifier output to file...")
+                print("\nSaving evidence type output file...")
                 evidence_type_output_content = {
                     "primary_domain": evidence_data.primary_domain,
                     "analyzed_sub_domains": evidence_data.analyzed_sub_domains,

--- a/steps/step4f_measurement_types.py
+++ b/steps/step4f_measurement_types.py
@@ -29,7 +29,7 @@ async def identify_measurement_types(
     topic_data: TopicSchema,
     overall_trace_id: Optional[str] = None
 ) -> Optional[MeasurementTypeSchema]:
-    """Identify measurement types (with relevance scores) based on domain, sub-domains, and topics.
+    """Identify measurement types based on domain, sub-domains, and topics.
 
     Args:
         content: The text content to analyze
@@ -78,7 +78,7 @@ async def identify_measurement_types(
         {"role": "user", "content": (
             f"Analyze the following text to identify key MEASUREMENT types (e.g., Financial Metric, Physical Quantity, Performance Indicator, Survey Result, Count, Ratio, Percentage). "
             f"Use the provided context:\n{context_summary_for_prompt}\n\n"
-            f"Identify measurement types relevant to this overall context and provide a relevance score (0.0-1.0) for each. "
+            f"Identify measurement types relevant to this overall context. "
             f"Output ONLY using the required MeasurementTypeSchema, including the primary_domain and analyzed_sub_domains list in the output."
         )},
         {"role": "user", "content": f"--- Full Text Start ---\n{content}\n--- Full Text End ---"}
@@ -114,15 +114,15 @@ async def identify_measurement_types(
                     logger.warning(f"Analyzed sub-domains in Step 4f output {measurement_data.analyzed_sub_domains} differs from Step 2 input { [sd.sub_domain for sd in sub_domain_data.identified_sub_domains]}. Using Step 4f's list.")
 
                 # Log and print results
-                measurement_log_items = [f"{item.measurement_type} (Score: {item.relevance_score:.2f})" for item in measurement_data.identified_measurements]
+                measurement_log_items = [item.measurement_type for item in measurement_data.identified_measurements]
                 logger.info(f"Step 4f Result: Identified Measurement Types = [{', '.join(measurement_log_items)}]")
-                logger.info(f"Step 4f Result (Structured Measurements with Scores):\n{measurement_data.model_dump_json(indent=2)}")
-                print("\n--- Measurement Types Identified (Structured Output from Step 4f with Relevance) ---")
+                logger.info(f"Step 4f Result (Structured Measurements):\n{measurement_data.model_dump_json(indent=2)}")
+                print("\n--- Measurement Types Identified (Structured Output from Step 4f) ---")
                 print(measurement_data.model_dump_json(indent=2))
 
                 # Save results
-                logger.info("Saving measurement type identifier output (with scores) to file...")
-                print("\nSaving measurement type output file (with scores)...")
+                logger.info("Saving measurement type identifier output to file...")
+                print("\nSaving measurement type output file...")
                 measurement_type_output_content = {
                     "primary_domain": measurement_data.primary_domain,
                     "analyzed_sub_domains": measurement_data.analyzed_sub_domains,

--- a/steps/step4g_modality_types.py
+++ b/steps/step4g_modality_types.py
@@ -29,7 +29,7 @@ async def identify_modality_types(
     topic_data: TopicSchema,
     overall_trace_id: Optional[str] = None
 ) -> Optional[ModalityTypeSchema]:
-    """Identify modality types (with relevance scores) based on domain, sub-domains, and topics.
+    """Identify modality types based on domain, sub-domains, and topics.
 
     Args:
         content: The text content to analyze
@@ -78,7 +78,7 @@ async def identify_modality_types(
         {"role": "user", "content": (
             f"Analyze the following text to identify key MODALITY types (e.g., Text, Image, Video, Audio, Table, Chart, Code Snippet, Formula). "
             f"Use the provided context:\n{context_summary_for_prompt}\n\n"
-            f"Identify modality types relevant to this overall context and provide a relevance score (0.0-1.0) for each. "
+            f"Identify modality types relevant to this overall context. "
             f"Output ONLY using the required ModalityTypeSchema, including the primary_domain and analyzed_sub_domains list in the output."
         )},
         {"role": "user", "content": f"--- Full Text Start ---\n{content}\n--- Full Text End ---"}
@@ -114,15 +114,15 @@ async def identify_modality_types(
                     logger.warning(f"Analyzed sub-domains in Step 4g output {modality_data.analyzed_sub_domains} differs from Step 2 input { [sd.sub_domain for sd in sub_domain_data.identified_sub_domains]}. Using Step 4g's list.")
 
                 # Log and print results
-                modality_log_items = [f"{item.modality_type} (Score: {item.relevance_score:.2f})" for item in modality_data.identified_modalities]
+                modality_log_items = [item.modality_type for item in modality_data.identified_modalities]
                 logger.info(f"Step 4g Result: Identified Modality Types = [{', '.join(modality_log_items)}]")
-                logger.info(f"Step 4g Result (Structured Modalities with Scores):\n{modality_data.model_dump_json(indent=2)}")
-                print("\n--- Modality Types Identified (Structured Output from Step 4g with Relevance) ---")
+                logger.info(f"Step 4g Result (Structured Modalities):\n{modality_data.model_dump_json(indent=2)}")
+                print("\n--- Modality Types Identified (Structured Output from Step 4g) ---")
                 print(modality_data.model_dump_json(indent=2))
 
                 # Save results
-                logger.info("Saving modality type identifier output (with scores) to file...")
-                print("\nSaving modality type output file (with scores)...")
+                logger.info("Saving modality type identifier output to file...")
+                print("\nSaving modality type output file...")
                 modality_type_output_content = {
                     "primary_domain": modality_data.primary_domain,
                     "analyzed_sub_domains": modality_data.analyzed_sub_domains,

--- a/steps/step5_relationship_types.py
+++ b/steps/step5_relationship_types.py
@@ -28,7 +28,7 @@ async def identify_relationship_types(
     entity_data: EntityTypeSchema,
     overall_trace_id: Optional[str] = None
 ) -> Optional[RelationshipSchema]:
-    """Identify relationship types (with relevance scores) for each entity type focus.
+    """Identify relationship types for each entity type focus.
     
     Args:
         content: The text content to analyze
@@ -77,12 +77,12 @@ async def identify_relationship_types(
         f"Overall Context:\n"
         f"- Primary Domain: {primary_domain}\n"
         f"- Identified Sub-Domains: {', '.join(sd.sub_domain for sd in sub_domain_data.identified_sub_domains)}\n"
-        f"- Identified Entity Types (with relevance scores): {', '.join(f'{et.entity_type} ({et.relevance_score:.1f})' for et in entity_data.identified_entities)}\n"
+        f"- Identified Entity Types: {', '.join(et.entity_type for et in entity_data.identified_entities)}\n"
         f"- Relevant Topics Found:\n"
     )
     topic_summary_lines = []
     for topic_map in topic_data.sub_domain_topic_map:
-        top_topics = [f"{t.topic} ({t.relevance_score:.1f})" for t in sorted(topic_map.identified_topics, key=lambda x: x.relevance_score, reverse=True)[:3]] # Top 3 topics per sub-domain
+        top_topics = [t.topic for t in topic_map.identified_topics[:3]]  # Top 3 topics per sub-domain
         if top_topics:
              topic_summary_lines.append(f"  - For '{topic_map.sub_domain}': {', '.join(top_topics)}{'...' if len(topic_map.identified_topics) > 3 else ''}")
     if not topic_summary_lines:
@@ -184,7 +184,7 @@ async def identify_relationship_types(
                     print(f"\n  --- Relationships involving Focus Type: '{current_entity_type}' ---")
                     if relation_details:
                         for rel in relation_details:
-                             print(f"     - {rel.relationship_type} (Score: {rel.relevance_score:.2f})")
+                             print(f"     - {rel.relationship_type}")
                     else:
                         print("     - (No specific relationships identified for this focus type)")
 


### PR DESCRIPTION
## Summary
- strip confidence and relevance score usage from step modules
- update prompts and output structures accordingly

## Testing
- `python -m py_compile $(git ls-files '*.py')`
