### PR TITLE
Refactor relationship instance extraction

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -317,10 +317,9 @@ async def run_combined_workflow(content: str) -> None:
                 content,
                 primary_domain,
                 sub_domain_data,
-                aggregated_instance_data,
                 relationship_data,
                 overall_trace_id,
-            ) if primary_domain and sub_domain_data and aggregated_instance_data and relationship_data else None
+            ) if primary_domain and sub_domain_data and relationship_data else None
 
 
             # Log completion status of individual steps (optional)

--- a/steps/step6_relationship_instances.py
+++ b/steps/step6_relationship_instances.py
@@ -18,7 +18,6 @@ from ..schemas import (
     RelationshipInstanceSchema,
     SubDomainSchema,
     RelationshipSchema,
-    ExtractedInstancesSchema,
 )
 from ..utils import direct_save_json_output, run_agent_with_retry
 
@@ -29,13 +28,12 @@ async def identify_relationship_instances(
     content: str,
     primary_domain: str,
     sub_domain_data: SubDomainSchema,
-    instance_data: ExtractedInstancesSchema,
     relationship_type_data: RelationshipSchema,
     overall_trace_id: Optional[str] = None,
 ) -> Optional[RelationshipInstanceSchema]:
     """Extract relationship instances using prior type results and instances."""
 
-    if not (primary_domain and sub_domain_data and instance_data and relationship_type_data):
+    if not (primary_domain and sub_domain_data and relationship_type_data):
         logger.info("Skipping Step 6b because prerequisites were not identified.")
         return None
 


### PR DESCRIPTION
## Summary
- remove unused `instance_data` argument from `identify_relationship_instances`
- drop aggregated instance requirement in orchestrator

## Testing
- `python -m py_compile $(git ls-files '*.py')`
