### PR TITLE
Remove extraneous path comments

### DIFF
--- a/agents.py
+++ b/agents.py
@@ -1,4 +1,3 @@
-# File: /Users/completetech/Desktop/python-agent-sdk/src/agentic_team_workflow/agents.py
 # NOTE: Using 'agentic_team' as the alias for the SDK import
 from typing import Any
 

--- a/config.py
+++ b/config.py
@@ -1,4 +1,3 @@
-# File: /Users/completetech/Desktop/python-agent-sdk/src/agentic_team_workflow/config.py
 import os
 import sys
 import logging

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1,4 +1,3 @@
-# File: /Users/completetech/Desktop/python-agent-sdk/src/agentic_team_workflow/orchestrator.py
 """Orchestrator module for the agentic team workflow.
 
 This module coordinates the workflow between different agent steps and handles tracing.

--- a/schemas.py
+++ b/schemas.py
@@ -1,4 +1,3 @@
-# File: /Users/completetech/Desktop/python-agent-sdk/src/agentic_team_workflow/schemas.py
 from typing import List, Optional
 from pydantic import BaseModel, Field
 

--- a/steps/__init__.py
+++ b/steps/__init__.py
@@ -1,4 +1,3 @@
-# File: /Users/completetech/Desktop/python-agent-sdk/src/agentic_team_workflow/steps/__init__.py
 """Agent workflow step modules for agentic_team_workflow."""
 
 from .step1_domain import identify_domain

--- a/steps/step4d_statement_types.py
+++ b/steps/step4d_statement_types.py
@@ -1,4 +1,3 @@
-# File: /Users/completetech/Desktop/python-agent-sdk/src/agentic_team_workflow/steps/step4d_statement_types.py
 """Step 4d: Statement type identification functionality."""
 
 import logging

--- a/steps/step4e_evidence_types.py
+++ b/steps/step4e_evidence_types.py
@@ -1,4 +1,3 @@
-# File: /Users/completetech/Desktop/python-agent-sdk/src/agentic_team_workflow/steps/step4e_evidence_types.py
 """Step 4e: Evidence type identification functionality."""
 
 import logging

--- a/steps/step4f_measurement_types.py
+++ b/steps/step4f_measurement_types.py
@@ -1,4 +1,3 @@
-# File: /Users/completetech/Desktop/python-agent-sdk/src/agentic_team_workflow/steps/step4f_measurement_types.py
 """Step 4f: Measurement type identification functionality."""
 
 import logging

--- a/steps/step4g_modality_types.py
+++ b/steps/step4g_modality_types.py
@@ -1,4 +1,3 @@
-# File: /Users/completetech/Desktop/python-agent-sdk/src/agentic_team_workflow/steps/step4g_modality_types.py
 """Step 4g: Modality type identification functionality."""
 
 import logging


### PR DESCRIPTION
## Summary
- drop leading `# File:` comments from modules so docstrings come first

## Testing
- `ruff check .`
- `mypy .`
