### PR TITLE
Refactor SDK import paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ This collaborative process, inspired by systems like [KARMA](https://arxiv.org/a
 ## Technology Stack
 
 * **Core:** Python 3.9+
-* **AI/ML:** Large Language Models (LLMs) via APIs (e.g., OpenAI, Anthropic, Google Gemini) or local models. Relies on an underlying LLM agent framework (like the one demonstrated in the provided file structure, e.g., `agentic_team`).
+* **AI/ML:** Large Language Models (LLMs) via APIs (e.g., OpenAI, Anthropic, Google Gemini) or local models. Relies on an underlying LLM agent framework (like the one demonstrated in the provided file structure, e.g., `agents`).
 * **Potential Libraries:**
     * `pydantic` (Data validation and schema definition)
     * `asyncio` (Concurrent agent execution)

--- a/agents.py
+++ b/agents.py
@@ -1,12 +1,10 @@
-# NOTE: Using 'agentic_team' as the alias for the SDK import
+# NOTE: Using the external ``agents`` SDK for agent definitions
 from typing import Any
 
 try:
-    from agentic_team import Agent  # type: ignore[attr-defined]
+    from agents import Agent  # type: ignore[attr-defined]
 except ImportError:
-    print(
-        "Error: 'agentic_team' SDK library not found or incomplete. Cannot define agents."
-    )
+    print("Error: 'agents' SDK library not found or incomplete. Cannot define agents.")
     # Depending on execution context, might want `sys.exit(1)` here,
     # but typically module-level errors are handled by the importer.
     Agent = Any  # type: ignore[misc]

--- a/config.py
+++ b/config.py
@@ -32,12 +32,12 @@ except ImportError:
     )
 
 # --- SDK Imports ---
-# NOTE: Using 'agentic_team' as the alias for the SDK import
+# NOTE: Using the external ``agents`` SDK
 try:
-    from agentic_team import set_default_openai_key
+    from agents import set_default_openai_key  # type: ignore[attr-defined]
 except ImportError:
     print(
-        "Error: 'agentic_team' SDK library not found or incomplete. Please ensure it is installed and accessible."
+        "Error: 'agents' SDK library not found or incomplete. Please ensure it is installed and accessible."
     )
     sys.exit(1)
 
@@ -203,18 +203,18 @@ if not API_KEY:
         )
     sys.exit(1)
 
-# Set API key for the 'agentic_team' SDK (or equivalent SDK function)
+# Set API key for the ``agents`` SDK (or equivalent SDK function)
 try:
     set_default_openai_key(API_KEY)
-    print("OpenAI API Key set for agentic_team SDK.")
+    print("OpenAI API Key set for agents SDK.")
 except NameError:
     print(
-        "Error: Could not set OpenAI key via agentic_team SDK (likely import failure).",
+        "Error: Could not set OpenAI key via agents SDK (likely import failure).",
         file=sys.stderr,
     )
     sys.exit(1)
 except Exception as e:
-    print(f"Error setting OpenAI key via agentic_team SDK: {e}", file=sys.stderr)
+    print(f"Error setting OpenAI key via agents SDK: {e}", file=sys.stderr)
     sys.exit(1)
 
 # --- Initial Logger Check ---

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -15,14 +15,14 @@ logger = logging.getLogger(__name__)
 
 # --- SDK Imports ---
 try:
-    from agentic_team import trace
+    from agents import trace  # type: ignore[attr-defined]
 except ImportError:
     logger.critical(
-        "CRITICAL Error: 'agentic_team' SDK library not found or incomplete. Cannot define orchestrator.",
+        "CRITICAL Error: 'agents' SDK library not found or incomplete. Cannot define orchestrator.",
         exc_info=True,
     )
     print(
-        "CRITICAL Error: 'agentic_team' SDK library not found or incomplete. Cannot define orchestrator.",
+        "CRITICAL Error: 'agents' SDK library not found or incomplete. Cannot define orchestrator.",
         file=sys.stderr,
     )
     raise  # Re-raise the import error

--- a/steps/__init__.py
+++ b/steps/__init__.py
@@ -1,4 +1,4 @@
-"""Agent workflow step modules for agentic_team_workflow."""
+"""Agent workflow step modules for the Graphyte workflow."""
 
 from .step1_domain import identify_domain
 from .step2_subdomains import identify_subdomains

--- a/steps/step1_domain.py
+++ b/steps/step1_domain.py
@@ -6,7 +6,7 @@ from typing import Dict, Any, Optional
 
 from pydantic import ValidationError
 
-from agentic_team import RunConfig, RunResult
+from agents import RunConfig, RunResult  # type: ignore[attr-defined]
 
 from ..agents import domain_identifier_agent
 from ..config import DOMAIN_MODEL, DOMAIN_OUTPUT_DIR, DOMAIN_OUTPUT_FILENAME

--- a/steps/step2_subdomains.py
+++ b/steps/step2_subdomains.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 from pydantic import ValidationError
 
-from agentic_team import RunConfig, RunResult, TResponseInputItem
+from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
 
 from ..agents import sub_domain_identifier_agent
 from ..config import SUB_DOMAIN_MODEL, SUB_DOMAIN_OUTPUT_DIR, SUB_DOMAIN_OUTPUT_FILENAME

--- a/steps/step3_topics.py
+++ b/steps/step3_topics.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 
 from pydantic import ValidationError
 
-from agentic_team import RunConfig, RunResult, TResponseInputItem
+from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
 
 from ..agents import topic_identifier_agent
 from ..config import TOPIC_MODEL, TOPIC_OUTPUT_DIR, TOPIC_OUTPUT_FILENAME

--- a/steps/step4a_entity_types.py
+++ b/steps/step4a_entity_types.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 from pydantic import ValidationError
 
-from agentic_team import RunConfig, RunResult, TResponseInputItem
+from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
 
 from ..agents import entity_type_identifier_agent
 from ..config import (

--- a/steps/step4b_ontology_types.py
+++ b/steps/step4b_ontology_types.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 from pydantic import ValidationError
 
-from agentic_team import RunConfig, RunResult, TResponseInputItem
+from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
 
 from ..agents import ontology_type_identifier_agent
 from ..config import (

--- a/steps/step4c_event_types.py
+++ b/steps/step4c_event_types.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 from pydantic import ValidationError
 
-from agentic_team import RunConfig, RunResult, TResponseInputItem
+from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
 
 from ..agents import event_type_identifier_agent  # Import the new agent
 from ..config import (

--- a/steps/step4d_statement_types.py
+++ b/steps/step4d_statement_types.py
@@ -6,11 +6,11 @@ from typing import List, Optional
 
 from pydantic import ValidationError
 
-# NOTE: Assuming 'agentic_team' is the correct SDK import alias
+# NOTE: Using the external ``agents`` SDK
 try:
-    from agentic_team import RunConfig, RunResult, TResponseInputItem
+    from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
 except ImportError:
-    print("Error: 'agentic_team' SDK library not found or incomplete for step 4d.")
+    print("Error: 'agents' SDK library not found or incomplete for step 4d.")
     raise
 
 from ..agents import statement_type_identifier_agent  # Import the new agent

--- a/steps/step4e_evidence_types.py
+++ b/steps/step4e_evidence_types.py
@@ -6,11 +6,11 @@ from typing import List, Optional
 
 from pydantic import ValidationError
 
-# NOTE: Assuming 'agentic_team' is the correct SDK import alias
+# NOTE: Using the external ``agents`` SDK
 try:
-    from agentic_team import RunConfig, RunResult, TResponseInputItem
+    from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
 except ImportError:
-    print("Error: 'agentic_team' SDK library not found or incomplete for step 4e.")
+    print("Error: 'agents' SDK library not found or incomplete for step 4e.")
     raise
 
 from ..agents import evidence_type_identifier_agent  # Import the new agent

--- a/steps/step4f_measurement_types.py
+++ b/steps/step4f_measurement_types.py
@@ -6,11 +6,11 @@ from typing import List, Optional
 
 from pydantic import ValidationError
 
-# NOTE: Assuming 'agentic_team' is the correct SDK import alias
+# NOTE: Using the external ``agents`` SDK
 try:
-    from agentic_team import RunConfig, RunResult, TResponseInputItem
+    from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
 except ImportError:
-    print("Error: 'agentic_team' SDK library not found or incomplete for step 4f.")
+    print("Error: 'agents' SDK library not found or incomplete for step 4f.")
     raise
 
 from ..agents import measurement_type_identifier_agent  # Import the new agent

--- a/steps/step4g_modality_types.py
+++ b/steps/step4g_modality_types.py
@@ -6,11 +6,11 @@ from typing import List, Optional
 
 from pydantic import ValidationError
 
-# NOTE: Assuming 'agentic_team' is the correct SDK import alias
+# NOTE: Using the external ``agents`` SDK
 try:
-    from agentic_team import RunConfig, RunResult, TResponseInputItem
+    from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
 except ImportError:
-    print("Error: 'agentic_team' SDK library not found or incomplete for step 4g.")
+    print("Error: 'agents' SDK library not found or incomplete for step 4g.")
     raise
 
 from ..agents import modality_type_identifier_agent  # Import the new agent

--- a/steps/step5_entity_instances.py
+++ b/steps/step5_entity_instances.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 from pydantic import ValidationError
 
-from agentic_team import RunConfig, RunResult, TResponseInputItem
+from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
 
 from ..agents import entity_instance_extractor_agent
 from ..config import (

--- a/steps/step5b_ontology_instances.py
+++ b/steps/step5b_ontology_instances.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 from pydantic import ValidationError
 
-from agentic_team import RunConfig, RunResult, TResponseInputItem
+from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
 
 from ..agents import ontology_instance_extractor_agent
 from ..config import (

--- a/steps/step5c_event_instances.py
+++ b/steps/step5c_event_instances.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 from pydantic import ValidationError
 
-from agentic_team import RunConfig, RunResult, TResponseInputItem
+from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
 
 from ..agents import event_instance_extractor_agent
 from ..config import (

--- a/steps/step5d_statement_instances.py
+++ b/steps/step5d_statement_instances.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 from pydantic import ValidationError
 
-from agentic_team import RunConfig, RunResult, TResponseInputItem
+from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
 
 from ..agents import statement_instance_extractor_agent
 from ..config import (

--- a/steps/step5e_evidence_instances.py
+++ b/steps/step5e_evidence_instances.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 from pydantic import ValidationError
 
-from agentic_team import RunConfig, RunResult, TResponseInputItem
+from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
 
 from ..agents import evidence_instance_extractor_agent
 from ..config import (

--- a/steps/step5f_measurement_instances.py
+++ b/steps/step5f_measurement_instances.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 from pydantic import ValidationError
 
-from agentic_team import RunConfig, RunResult, TResponseInputItem
+from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
 
 from ..agents import measurement_instance_extractor_agent
 from ..config import (

--- a/steps/step5g_modality_instances.py
+++ b/steps/step5g_modality_instances.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 from pydantic import ValidationError
 
-from agentic_team import RunConfig, RunResult, TResponseInputItem
+from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
 
 from ..agents import modality_instance_extractor_agent
 from ..config import (

--- a/steps/step6a_relationship_types.py
+++ b/steps/step6a_relationship_types.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 
 from pydantic import ValidationError
 
-from agentic_team import RunConfig, RunResult, TResponseInputItem
+from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
 
 from ..agents import relationship_type_identifier_agent
 from ..config import (

--- a/steps/step6b_relationship_instances.py
+++ b/steps/step6b_relationship_instances.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 from pydantic import ValidationError
 
-from agentic_team import RunConfig, RunResult, TResponseInputItem
+from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
 
 from ..agents import relationship_extractor_agent
 from ..config import (

--- a/steps/visualization.py
+++ b/steps/visualization.py
@@ -23,16 +23,16 @@ except ImportError:
     # Define a dummy draw_graph if not available to avoid NameError later
     def draw_graph(*args, **kwargs):
         logger.error(
-            "Visualization requested, but 'agentic_team[viz]' extras not installed, Graphviz is missing, or import failed (expected 'agents.extensions.visualization')."
+            "Visualization requested, but 'agents[viz]' extras not installed, Graphviz is missing, or import failed (expected 'agents.extensions.visualization')."
         )
         print(
-            "ERROR: Visualization generation failed. Please install 'agentic_team[viz]' (or similar extras) and ensure Graphviz is installed and in PATH.",
+            "ERROR: Visualization generation failed. Please install 'agents[viz]' (or similar extras) and ensure Graphviz is installed and in PATH.",
             file=sys.stderr,
         )
         return None
 
     logger.warning(
-        "Could not import 'draw_graph' from 'agents.extensions.visualization'. Visualization will be unavailable. Ensure 'agentic_team[viz]' (or similar) is installed."
+        "Could not import 'draw_graph' from 'agents.extensions.visualization'. Visualization will be unavailable. Ensure 'agents[viz]' (or similar) is installed."
     )
 
 

--- a/utils.py
+++ b/utils.py
@@ -26,9 +26,9 @@ try:
 except ImportError:
     TENACITY_AVAILABLE = False
 
-# NOTE: Using 'agentic_team' as the alias for the SDK import
+# NOTE: Using the external ``agents`` SDK
 try:
-    from agentic_team import (
+    from agents import (  # type: ignore[attr-defined]
         Agent,
         Runner,
         RunConfig,
@@ -37,9 +37,7 @@ try:
         AgentsException,  # Import base SDK exception for retry
     )
 except ImportError:
-    print(
-        "Error: 'agentic_team' SDK library not found or incomplete. Cannot define utils."
-    )
+    print("Error: 'agents' SDK library not found or incomplete. Cannot define utils.")
     raise
 
 # Import config constants needed in utils


### PR DESCRIPTION
## Summary
- switch to new `agents` SDK imports across the codebase
- update error messages and comments mentioning the old path
- annotate external SDK imports for mypy

## Testing
- `black .`
- `ruff check .`
- `mypy .`
