### PR TITLE
Add scoring tools to type identifier agent

### DIFF
--- a/graphyte_ai/workflow_agents.py
+++ b/graphyte_ai/workflow_agents.py
@@ -178,7 +178,20 @@ base_type_identifier_agent = Agent(
     name="BaseTypeIdentifierAgent",  # Generic name, will be overridden
     instructions=base_type_identifier_instructions_template,  # Will be formatted in clones
     # No default model or output_type, must be specified in clones
-    tools=[],
+    tools=[
+        confidence_score_agent.as_tool(
+            tool_name="confidence_score",
+            tool_description="Evaluate confidence between 0.0 and 1.0",
+        ),
+        relevance_score_agent.as_tool(
+            tool_name="relevance_score",
+            tool_description="Judge relevance between 0.0 and 1.0",
+        ),
+        clarity_score_agent.as_tool(
+            tool_name="clarity_score",
+            tool_description="Assess clarity between 0.0 and 1.0",
+        ),
+    ],
     handoffs=[],
 )
 


### PR DESCRIPTION
## Summary
- wire scoring agents into BaseTypeIdentifierAgent
- run format, lint and type checks

## Testing
- `ruff check .`
- `mypy .`
