### PR TITLE
Add scoring fields to step 4 detail schemas

### DIFF
--- a/graphyte_ai/schemas.py
+++ b/graphyte_ai/schemas.py
@@ -117,6 +117,18 @@ class EntityTypeDetail(BaseModel):
             "DATE, MONEY, PRODUCT, TECHNOLOGY, SCIENTIFIC_CONCEPT, ECONOMIC_INDICATOR)."  # Removed EVENT as it's now separate
         )
     )
+    confidence_score: Optional[float] = Field(
+        None,
+        description="Optional confidence score (0.0 to 1.0) for this entity type.",
+    )
+    relevance_score: Optional[float] = Field(
+        None,
+        description="Optional relevance score (0.0 to 1.0) for this entity type.",
+    )
+    clarity_score: Optional[float] = Field(
+        None,
+        description="Optional clarity score (0.0 to 1.0) for this entity type.",
+    )
 
 
 # Schema for entity type analysis output (Agent 4a)
@@ -147,6 +159,18 @@ class OntologyTypeDetail(BaseModel):
             "The identified ontology type or concept (e.g., Schema.org:Person, FIBO:FinancialInstrument, GO:biological_process)."
         )
     )
+    confidence_score: Optional[float] = Field(
+        None,
+        description="Optional confidence score (0.0 to 1.0) for this ontology type.",
+    )
+    relevance_score: Optional[float] = Field(
+        None,
+        description="Optional relevance score (0.0 to 1.0) for this ontology type.",
+    )
+    clarity_score: Optional[float] = Field(
+        None,
+        description="Optional clarity score (0.0 to 1.0) for this ontology type.",
+    )
 
 
 # Schema for ontology type analysis output (Agent 4b)
@@ -176,6 +200,18 @@ class EventDetail(BaseModel):
         description=(
             "The classified type of the event identified (e.g., Meeting, Acquisition, Conference, Product Launch, Election, Natural Disaster)."
         )
+    )
+    confidence_score: Optional[float] = Field(
+        None,
+        description="Optional confidence score (0.0 to 1.0) for this event type.",
+    )
+    relevance_score: Optional[float] = Field(
+        None,
+        description="Optional relevance score (0.0 to 1.0) for this event type.",
+    )
+    clarity_score: Optional[float] = Field(
+        None,
+        description="Optional clarity score (0.0 to 1.0) for this event type.",
     )
     # Optional: Add description if needed, like 'Brief description of the event instance'
     # description: Optional[str] = Field(None, description="A brief description or name of the specific event instance.")
@@ -211,6 +247,18 @@ class StatementDetail(BaseModel):
     )
     # Optional: Add a snippet of the text classified
     # supporting_text: Optional[str] = Field(None, description="The text snippet classified as this statement type.")
+    confidence_score: Optional[float] = Field(
+        None,
+        description="Optional confidence score (0.0 to 1.0) for this statement type.",
+    )
+    relevance_score: Optional[float] = Field(
+        None,
+        description="Optional relevance score (0.0 to 1.0) for this statement type.",
+    )
+    clarity_score: Optional[float] = Field(
+        None,
+        description="Optional clarity score (0.0 to 1.0) for this statement type.",
+    )
 
 
 # Schema for statement type analysis output (Agent 4d)
@@ -240,6 +288,18 @@ class EvidenceDetail(BaseModel):
         description=(
             "The classified type of evidence identified (e.g., Testimony, Document, Statistic, Anecdote, Expert Opinion, Observation, Example)."
         )
+    )
+    confidence_score: Optional[float] = Field(
+        None,
+        description="Optional confidence score (0.0 to 1.0) for this evidence type.",
+    )
+    relevance_score: Optional[float] = Field(
+        None,
+        description="Optional relevance score (0.0 to 1.0) for this evidence type.",
+    )
+    clarity_score: Optional[float] = Field(
+        None,
+        description="Optional clarity score (0.0 to 1.0) for this evidence type.",
     )
 
 
@@ -274,6 +334,18 @@ class MeasurementDetail(BaseModel):
     # Optional: Add unit or value if needed
     # unit: Optional[str] = Field(None, description="The unit of the measurement, if applicable.")
     # value: Optional[str] = Field(None, description="The actual value mentioned, if relevant.")
+    confidence_score: Optional[float] = Field(
+        None,
+        description="Optional confidence score (0.0 to 1.0) for this measurement type.",
+    )
+    relevance_score: Optional[float] = Field(
+        None,
+        description="Optional relevance score (0.0 to 1.0) for this measurement type.",
+    )
+    clarity_score: Optional[float] = Field(
+        None,
+        description="Optional clarity score (0.0 to 1.0) for this measurement type.",
+    )
 
 
 # Schema for measurement type analysis output (Agent 4f)
@@ -306,6 +378,18 @@ class ModalityDetail(BaseModel):
     )
     # Optional: Add count or description if needed
     # count: Optional[int] = Field(None, description="Number of times this modality is represented, if applicable.")
+    confidence_score: Optional[float] = Field(
+        None,
+        description="Optional confidence score (0.0 to 1.0) for this modality type.",
+    )
+    relevance_score: Optional[float] = Field(
+        None,
+        description="Optional relevance score (0.0 to 1.0) for this modality type.",
+    )
+    clarity_score: Optional[float] = Field(
+        None,
+        description="Optional clarity score (0.0 to 1.0) for this modality type.",
+    )
 
 
 # Schema for modality type analysis output (Agent 4g - NEW)


### PR DESCRIPTION
## Summary
- extend step 4 `*Detail` models with optional `confidence_score`, `relevance_score`, and `clarity_score` fields
- confirm step 4 saving code already dumps models so new fields persist

## Testing
- `black . --quiet`
- `ruff check .`
- `mypy .` *(fails: "ExtractedInstancesSchema has no attribute 'model_dump_json'" and more)*