### PR TITLE
feat: centralize scoring fields

### DIFF
--- a/graphyte_ai/orchestrator.py
+++ b/graphyte_ai/orchestrator.py
@@ -6,7 +6,6 @@ This module coordinates the workflow between different agent steps and handles t
 import asyncio  # Added for gather
 import logging
 import sys
-from datetime import datetime, timezone
 from typing import Any, Optional, List
 
 
@@ -33,19 +32,15 @@ from .config import (  # noqa: E402
     SUB_DOMAIN_MODEL,
     TOPIC_MODEL,
     ENTITY_TYPE_MODEL,
-    ONTOLOGY_TYPE_MODEL,
     EVENT_TYPE_MODEL,
     STATEMENT_TYPE_MODEL,
     EVIDENCE_TYPE_MODEL,
     MEASUREMENT_TYPE_MODEL,
-    MODALITY_TYPE_MODEL,
     ENTITY_INSTANCE_MODEL,
-    ONTOLOGY_INSTANCE_MODEL,
     EVENT_INSTANCE_MODEL,
     STATEMENT_INSTANCE_MODEL,
     EVIDENCE_INSTANCE_MODEL,
     MEASUREMENT_INSTANCE_MODEL,
-    MODALITY_INSTANCE_MODEL,
     RELATIONSHIP_MODEL,
     RELATIONSHIP_INSTANCE_MODEL,
     AGENT_TRACE_BASE_URL,
@@ -123,25 +118,25 @@ async def run_combined_workflow(content: str) -> None:
     # Metadata for the single overall trace
     overall_trace_metadata = {
         "workflow_name": "Document Analysis",
-        #"input_content_length": str(len(content)),
-        #"start_timestamp_utc": datetime.now(timezone.utc).isoformat(),
+        # "input_content_length": str(len(content)),
+        # "start_timestamp_utc": datetime.now(timezone.utc).isoformat(),
         "domain_model": DOMAIN_MODEL,
         "sub_domain_model": SUB_DOMAIN_MODEL,
         "topic_model": TOPIC_MODEL,
         "entity_type_model": ENTITY_TYPE_MODEL,
-        #"ontology_type_model": ONTOLOGY_TYPE_MODEL,
+        # "ontology_type_model": ONTOLOGY_TYPE_MODEL,
         "event_type_model": EVENT_TYPE_MODEL,
         "statement_type_model": STATEMENT_TYPE_MODEL,
         "evidence_type_model": EVIDENCE_TYPE_MODEL,
         "measurement_type_model": MEASUREMENT_TYPE_MODEL,
-        #"modality_type_model": MODALITY_TYPE_MODEL,  # Added modality model (4g)
+        # "modality_type_model": MODALITY_TYPE_MODEL,  # Added modality model (4g)
         "entity_instance_model": ENTITY_INSTANCE_MODEL,
-        #"ontology_instance_model": ONTOLOGY_INSTANCE_MODEL,
+        # "ontology_instance_model": ONTOLOGY_INSTANCE_MODEL,
         "event_instance_model": EVENT_INSTANCE_MODEL,
         "statement_instance_model": STATEMENT_INSTANCE_MODEL,
         "evidence_instance_model": EVIDENCE_INSTANCE_MODEL,
         "measurement_instance_model": MEASUREMENT_INSTANCE_MODEL,
-        #"modality_instance_model": MODALITY_INSTANCE_MODEL,
+        # "modality_instance_model": MODALITY_INSTANCE_MODEL,
         "relationship_model": RELATIONSHIP_MODEL,
         "relationship_instance_model": RELATIONSHIP_INSTANCE_MODEL,
     }

--- a/graphyte_ai/schemas.py
+++ b/graphyte_ai/schemas.py
@@ -1,11 +1,35 @@
 from typing import List, Optional
 from pydantic import BaseModel, Field
 
+
+class ScoredModel(BaseModel):
+    """Mixin providing optional scoring fields constrained between 0 and 1."""
+
+    confidence_score: Optional[float] = Field(
+        None,
+        description="Optional confidence score (0.0 to 1.0).",
+        ge=0.0,
+        le=1.0,
+    )
+    relevance_score: Optional[float] = Field(
+        None,
+        description="Optional relevance score (0.0 to 1.0).",
+        ge=0.0,
+        le=1.0,
+    )
+    clarity_score: Optional[float] = Field(
+        None,
+        description="Optional clarity score (0.0 to 1.0).",
+        ge=0.0,
+        le=1.0,
+    )
+
+
 # --- Schemas for Existing Agents (1-3) ---
 
 
 # Schema for primary domain output (Agent 1)
-class DomainSchema(BaseModel):
+class DomainSchema(ScoredModel):
     """Schema defining the expected output: the primary domain."""
 
     domain: str = Field(
@@ -15,18 +39,7 @@ class DomainSchema(BaseModel):
         )
     )
 
-    confidence_score: Optional[float] = Field(
-        None,
-        description="Optional confidence score (0.0 to 1.0) for the domain identification.",
-    )
-    relevance_score: Optional[float] = Field(
-        None,
-        description="Optional relevance score (0.0 to 1.0) indicating how strongly the domain relates to the text.",
-    )
-    clarity_score: Optional[float] = Field(
-        None,
-        description="Optional clarity score (0.0 to 1.0) showing how well-defined the domain is in context.",
-    )
+    # scoring fields inherited from ``ScoredModel``
 
 
 # Simple schema used when only a confidence score is needed
@@ -63,24 +76,13 @@ class ClarityScoreSchema(BaseModel):
 
 
 # Nested schema for a sub-domain
-class SubDomainDetail(BaseModel):
+class SubDomainDetail(ScoredModel):
     """Represents a single identified sub-domain."""
 
     sub_domain: str = Field(
         description="The specific sub-domain identified within the text."
     )
-    confidence_score: Optional[float] = Field(
-        None,
-        description="Optional confidence score (0.0 to 1.0) for this sub-domain.",
-    )
-    relevance_score: Optional[float] = Field(
-        None,
-        description="Optional relevance score (0.0 to 1.0) expressing how strongly this sub-domain relates to the text.",
-    )
-    clarity_score: Optional[float] = Field(
-        None,
-        description="Optional clarity score (0.0 to 1.0) for how clearly this sub-domain is defined in context.",
-    )
+    # scoring fields inherited from ``ScoredModel``
 
 
 # Schema for sub-domain analysis output (Agent 2)
@@ -99,22 +101,11 @@ class SubDomainSchema(BaseModel):
 
 
 # Nested schema for a topic
-class TopicDetail(BaseModel):
+class TopicDetail(ScoredModel):
     """Represents a single identified topic."""
 
     topic: str = Field(description="The specific topic identified within the text.")
-    confidence_score: Optional[float] = Field(
-        None,
-        description="Optional confidence score (0.0 to 1.0) for this topic.",
-    )
-    relevance_score: Optional[float] = Field(
-        None,
-        description="Optional relevance score (0.0 to 1.0) indicating how strongly the topic relates to the text.",
-    )
-    clarity_score: Optional[float] = Field(
-        None,
-        description="Optional clarity score (0.0 to 1.0) for how clearly the topic is defined in context.",
-    )
+    # scoring fields inherited from ``ScoredModel``
 
 
 # Schema for the output of the *single* topic identification agent call (Agent 3)
@@ -145,7 +136,7 @@ class TopicSchema(BaseModel):
 
 
 # Nested schema for an entity type (Agent 4a)
-class EntityTypeDetail(BaseModel):
+class EntityTypeDetail(ScoredModel):
     """Represents an entity type with optional scoring information."""
 
     entity_type: str = Field(
@@ -154,18 +145,7 @@ class EntityTypeDetail(BaseModel):
             "DATE, MONEY, PRODUCT, TECHNOLOGY, SCIENTIFIC_CONCEPT, ECONOMIC_INDICATOR)."  # Removed EVENT as it's now separate
         )
     )
-    confidence_score: Optional[float] = Field(
-        None,
-        description="Optional confidence score (0.0 to 1.0) for this entity type.",
-    )
-    relevance_score: Optional[float] = Field(
-        None,
-        description="Optional relevance score (0.0 to 1.0) for this entity type.",
-    )
-    clarity_score: Optional[float] = Field(
-        None,
-        description="Optional clarity score (0.0 to 1.0) for this entity type.",
-    )
+    # scoring fields inherited from ``ScoredModel``
 
 
 # Schema for entity type analysis output (Agent 4a)
@@ -188,7 +168,7 @@ class EntityTypeSchema(BaseModel):
 
 
 # Nested schema for an ontology type/concept (Agent 4b)
-class OntologyTypeDetail(BaseModel):
+class OntologyTypeDetail(ScoredModel):
     """Represents an ontology type or concept with optional scoring information."""
 
     ontology_type: str = Field(
@@ -196,18 +176,7 @@ class OntologyTypeDetail(BaseModel):
             "The identified ontology type or concept (e.g., Schema.org:Person, FIBO:FinancialInstrument, GO:biological_process)."
         )
     )
-    confidence_score: Optional[float] = Field(
-        None,
-        description="Optional confidence score (0.0 to 1.0) for this ontology type.",
-    )
-    relevance_score: Optional[float] = Field(
-        None,
-        description="Optional relevance score (0.0 to 1.0) for this ontology type.",
-    )
-    clarity_score: Optional[float] = Field(
-        None,
-        description="Optional clarity score (0.0 to 1.0) for this ontology type.",
-    )
+    # scoring fields inherited from ``ScoredModel``
 
 
 # Schema for ontology type analysis output (Agent 4b)
@@ -230,7 +199,7 @@ class OntologyTypeSchema(BaseModel):
 
 
 # Nested schema for an event type (Agent 4c)
-class EventDetail(BaseModel):
+class EventDetail(ScoredModel):
     """Represents an identified event type with optional scoring information."""
 
     event_type: str = Field(
@@ -238,18 +207,7 @@ class EventDetail(BaseModel):
             "The classified type of the event identified (e.g., Meeting, Acquisition, Conference, Product Launch, Election, Natural Disaster)."
         )
     )
-    confidence_score: Optional[float] = Field(
-        None,
-        description="Optional confidence score (0.0 to 1.0) for this event type.",
-    )
-    relevance_score: Optional[float] = Field(
-        None,
-        description="Optional relevance score (0.0 to 1.0) for this event type.",
-    )
-    clarity_score: Optional[float] = Field(
-        None,
-        description="Optional clarity score (0.0 to 1.0) for this event type.",
-    )
+    # scoring fields inherited from ``ScoredModel``
     # Optional: Add description if needed, like 'Brief description of the event instance'
     # description: Optional[str] = Field(None, description="A brief description or name of the specific event instance.")
 
@@ -274,7 +232,7 @@ class EventTypeSchema(BaseModel):
 
 
 # Nested schema for a statement type (Agent 4d)
-class StatementDetail(BaseModel):
+class StatementDetail(ScoredModel):
     """Represents an identified statement type with optional scoring information."""
 
     statement_type: str = Field(
@@ -282,18 +240,7 @@ class StatementDetail(BaseModel):
             "The classified type of the statement identified (e.g., Fact, Claim, Opinion, Question, Instruction, Hypothesis, Prediction)."
         )
     )
-    confidence_score: Optional[float] = Field(
-        None,
-        description="Optional confidence score (0.0 to 1.0) for this statement type.",
-    )
-    relevance_score: Optional[float] = Field(
-        None,
-        description="Optional relevance score (0.0 to 1.0) for this statement type.",
-    )
-    clarity_score: Optional[float] = Field(
-        None,
-        description="Optional clarity score (0.0 to 1.0) for this statement type.",
-    )
+    # scoring fields inherited from ``ScoredModel``
     # Optional: Add a snippet of the text classified
     # supporting_text: Optional[str] = Field(None, description="The text snippet classified as this statement type.")
 
@@ -318,7 +265,7 @@ class StatementTypeSchema(BaseModel):
 
 
 # Nested schema for an evidence type (Agent 4e)
-class EvidenceDetail(BaseModel):
+class EvidenceDetail(ScoredModel):
     """Represents an identified evidence type with optional scoring information."""
 
     evidence_type: str = Field(
@@ -326,18 +273,7 @@ class EvidenceDetail(BaseModel):
             "The classified type of evidence identified (e.g., Testimony, Document, Statistic, Anecdote, Expert Opinion, Observation, Example)."
         )
     )
-    confidence_score: Optional[float] = Field(
-        None,
-        description="Optional confidence score (0.0 to 1.0) for this evidence type.",
-    )
-    relevance_score: Optional[float] = Field(
-        None,
-        description="Optional relevance score (0.0 to 1.0) for this evidence type.",
-    )
-    clarity_score: Optional[float] = Field(
-        None,
-        description="Optional clarity score (0.0 to 1.0) for this evidence type.",
-    )
+    # scoring fields inherited from ``ScoredModel``
 
 
 # Schema for evidence type analysis output (Agent 4e)
@@ -360,7 +296,7 @@ class EvidenceTypeSchema(BaseModel):
 
 
 # Nested schema for a measurement type (Agent 4f)
-class MeasurementDetail(BaseModel):
+class MeasurementDetail(ScoredModel):
     """Represents an identified measurement type with optional scoring information."""
 
     measurement_type: str = Field(
@@ -371,18 +307,7 @@ class MeasurementDetail(BaseModel):
     # Optional: Add unit or value if needed
     # unit: Optional[str] = Field(None, description="The unit of the measurement, if applicable.")
     # value: Optional[str] = Field(None, description="The actual value mentioned, if relevant.")
-    confidence_score: Optional[float] = Field(
-        None,
-        description="Optional confidence score (0.0 to 1.0) for this measurement type.",
-    )
-    relevance_score: Optional[float] = Field(
-        None,
-        description="Optional relevance score (0.0 to 1.0) for this measurement type.",
-    )
-    clarity_score: Optional[float] = Field(
-        None,
-        description="Optional clarity score (0.0 to 1.0) for this measurement type.",
-    )
+    # scoring fields inherited from ``ScoredModel``
 
 
 # Schema for measurement type analysis output (Agent 4f)
@@ -405,7 +330,7 @@ class MeasurementTypeSchema(BaseModel):
 
 
 # Nested schema for a modality type (Agent 4g - NEW)
-class ModalityDetail(BaseModel):
+class ModalityDetail(ScoredModel):
     """Represents an identified modality type with optional scoring information."""
 
     modality_type: str = Field(
@@ -415,18 +340,7 @@ class ModalityDetail(BaseModel):
     )
     # Optional: Add count or description if needed
     # count: Optional[int] = Field(None, description="Number of times this modality is represented, if applicable.")
-    confidence_score: Optional[float] = Field(
-        None,
-        description="Optional confidence score (0.0 to 1.0) for this modality type.",
-    )
-    relevance_score: Optional[float] = Field(
-        None,
-        description="Optional relevance score (0.0 to 1.0) for this modality type.",
-    )
-    clarity_score: Optional[float] = Field(
-        None,
-        description="Optional clarity score (0.0 to 1.0) for this modality type.",
-    )
+    # scoring fields inherited from ``ScoredModel``
 
 
 # Schema for modality type analysis output (Agent 4g - NEW)
@@ -451,7 +365,7 @@ class ModalityTypeSchema(BaseModel):
 # --- Schema for Step 5: Entity Instance Extraction ---
 
 
-class EntityInstanceDetail(BaseModel):
+class EntityInstanceDetail(ScoredModel):
     """Represents a specific entity mention extracted from the text."""
 
     entity_type: str = Field(
@@ -466,18 +380,7 @@ class EntityInstanceDetail(BaseModel):
         None,
         description="End character index of the mention in the full text (exclusive).",
     )
-    confidence_score: Optional[float] = Field(
-        None,
-        description="Optional confidence score (0.0 to 1.0) for this entity instance.",
-    )
-    relevance_score: Optional[float] = Field(
-        None,
-        description="Optional relevance score (0.0 to 1.0) for this entity instance.",
-    )
-    clarity_score: Optional[float] = Field(
-        None,
-        description="Optional clarity score (0.0 to 1.0) for this entity instance.",
-    )
+    # scoring fields inherited from ``ScoredModel``
 
 
 class EntityInstanceSchema(BaseModel):
@@ -503,7 +406,7 @@ class EntityInstanceSchema(BaseModel):
 # --- Schema for Step 5b: Ontology Instance Extraction ---
 
 
-class OntologyInstanceDetail(BaseModel):
+class OntologyInstanceDetail(ScoredModel):
     """Represents a specific ontology concept mention extracted from the text."""
 
     ontology_type: str = Field(
@@ -518,18 +421,7 @@ class OntologyInstanceDetail(BaseModel):
         None,
         description="End character index of the mention in the full text (exclusive).",
     )
-    confidence_score: Optional[float] = Field(
-        None,
-        description="Optional confidence score (0.0 to 1.0) for this ontology instance.",
-    )
-    relevance_score: Optional[float] = Field(
-        None,
-        description="Optional relevance score (0.0 to 1.0) for this ontology instance.",
-    )
-    clarity_score: Optional[float] = Field(
-        None,
-        description="Optional clarity score (0.0 to 1.0) for this ontology instance.",
-    )
+    # scoring fields inherited from ``ScoredModel``
 
 
 class OntologyInstanceSchema(BaseModel):
@@ -556,7 +448,7 @@ class OntologyInstanceSchema(BaseModel):
 # --- Schema for Step 5c: Event Instance Extraction ---
 
 
-class EventInstanceDetail(BaseModel):
+class EventInstanceDetail(ScoredModel):
     """Represents a specific event mention extracted from the text."""
 
     event_type: str = Field(
@@ -571,18 +463,7 @@ class EventInstanceDetail(BaseModel):
         None,
         description="End character index of the mention in the full text (exclusive).",
     )
-    confidence_score: Optional[float] = Field(
-        None,
-        description="Optional confidence score (0.0 to 1.0) for this event instance.",
-    )
-    relevance_score: Optional[float] = Field(
-        None,
-        description="Optional relevance score (0.0 to 1.0) for this event instance.",
-    )
-    clarity_score: Optional[float] = Field(
-        None,
-        description="Optional clarity score (0.0 to 1.0) for this event instance.",
-    )
+    # scoring fields inherited from ``ScoredModel``
 
 
 class EventInstanceSchema(BaseModel):
@@ -608,7 +489,7 @@ class EventInstanceSchema(BaseModel):
 # --- Schema for Step 5d: Statement Instance Extraction ---
 
 
-class StatementInstanceDetail(BaseModel):
+class StatementInstanceDetail(ScoredModel):
     """Represents a specific statement mention extracted from the text."""
 
     statement_type: str = Field(
@@ -625,18 +506,7 @@ class StatementInstanceDetail(BaseModel):
         None,
         description="End character index of the statement in the full text (exclusive).",
     )
-    confidence_score: Optional[float] = Field(
-        None,
-        description="Optional confidence score (0.0 to 1.0) for this statement instance.",
-    )
-    relevance_score: Optional[float] = Field(
-        None,
-        description="Optional relevance score (0.0 to 1.0) for this statement instance.",
-    )
-    clarity_score: Optional[float] = Field(
-        None,
-        description="Optional clarity score (0.0 to 1.0) for this statement instance.",
-    )
+    # scoring fields inherited from ``ScoredModel``
 
 
 class StatementInstanceSchema(BaseModel):
@@ -663,7 +533,7 @@ class StatementInstanceSchema(BaseModel):
 # --- Schema for Step 5e: Evidence Instance Extraction ---
 
 
-class EvidenceInstanceDetail(BaseModel):
+class EvidenceInstanceDetail(ScoredModel):
     """Represents a specific evidence mention extracted from the text."""
 
     evidence_type: str = Field(
@@ -678,18 +548,7 @@ class EvidenceInstanceDetail(BaseModel):
         None,
         description="End character index of the mention in the full text (exclusive).",
     )
-    confidence_score: Optional[float] = Field(
-        None,
-        description="Optional confidence score (0.0 to 1.0) for this evidence instance.",
-    )
-    relevance_score: Optional[float] = Field(
-        None,
-        description="Optional relevance score (0.0 to 1.0) for this evidence instance.",
-    )
-    clarity_score: Optional[float] = Field(
-        None,
-        description="Optional clarity score (0.0 to 1.0) for this evidence instance.",
-    )
+    # scoring fields inherited from ``ScoredModel``
 
 
 class EvidenceInstanceSchema(BaseModel):
@@ -716,7 +575,7 @@ class EvidenceInstanceSchema(BaseModel):
 # --- Schema for Step 5f: Measurement Instance Extraction ---
 
 
-class MeasurementInstanceDetail(BaseModel):
+class MeasurementInstanceDetail(ScoredModel):
     """Represents a specific measurement mention extracted from the text."""
 
     measurement_type: str = Field(
@@ -731,18 +590,7 @@ class MeasurementInstanceDetail(BaseModel):
         None,
         description="End character index of the mention in the full text (exclusive).",
     )
-    confidence_score: Optional[float] = Field(
-        None,
-        description="Optional confidence score (0.0 to 1.0) for this measurement instance.",
-    )
-    relevance_score: Optional[float] = Field(
-        None,
-        description="Optional relevance score (0.0 to 1.0) for this measurement instance.",
-    )
-    clarity_score: Optional[float] = Field(
-        None,
-        description="Optional clarity score (0.0 to 1.0) for this measurement instance.",
-    )
+    # scoring fields inherited from ``ScoredModel``
 
 
 class MeasurementInstanceSchema(BaseModel):
@@ -769,7 +617,7 @@ class MeasurementInstanceSchema(BaseModel):
 # --- Schema for Step 5g: Modality Instance Extraction ---
 
 
-class ModalityInstanceDetail(BaseModel):
+class ModalityInstanceDetail(ScoredModel):
     """Represents a specific modality mention extracted from the text."""
 
     modality_type: str = Field(
@@ -786,18 +634,7 @@ class ModalityInstanceDetail(BaseModel):
         None,
         description="End character index of the mention in the full text (exclusive).",
     )
-    confidence_score: Optional[float] = Field(
-        None,
-        description="Optional confidence score (0.0 to 1.0) for this modality instance.",
-    )
-    relevance_score: Optional[float] = Field(
-        None,
-        description="Optional relevance score (0.0 to 1.0) for this modality instance.",
-    )
-    clarity_score: Optional[float] = Field(
-        None,
-        description="Optional clarity score (0.0 to 1.0) for this modality instance.",
-    )
+    # scoring fields inherited from ``ScoredModel``
 
 
 class ModalityInstanceSchema(BaseModel):
@@ -825,24 +662,13 @@ class ModalityInstanceSchema(BaseModel):
 
 
 # Nested schema for a specific identified relationship between entities
-class RelationshipDetail(BaseModel):
+class RelationshipDetail(ScoredModel):
     """Represents a single identified relationship between two entities with optional scoring information."""
 
     relationship_type: str = Field(
         description="The nature of the relationship identified (e.g., WORKS_FOR, LOCATED_IN, ACQUIRED, PARTNERS_WITH, COMPETES_WITH)."
     )
-    confidence_score: Optional[float] = Field(
-        None,
-        description="Optional confidence score (0.0 to 1.0) for identifying this relationship type.",
-    )
-    relevance_score: Optional[float] = Field(
-        None,
-        description="Optional relevance score (0.0 to 1.0) for identifying this relationship type.",
-    )
-    clarity_score: Optional[float] = Field(
-        None,
-        description="Optional clarity score (0.0 to 1.0) for identifying this relationship type.",
-    )
+    # scoring fields inherited from ``ScoredModel``
     # Optional: Add a field for the sentence/snippet supporting the relationship
     # supporting_text: Optional[str] = Field(None, description="The text snippet that supports this relationship finding.")
 
@@ -883,7 +709,7 @@ class RelationshipSchema(BaseModel):
 
 
 # --- Schema for Step 6: Relationship Instance Extraction ---
-class RelationshipInstanceDetail(BaseModel):
+class RelationshipInstanceDetail(ScoredModel):
     """Represents a specific relationship instance between two entities.
 
     Optional scoring fields ``confidence_score``, ``relevance_score`` and
@@ -900,18 +726,7 @@ class RelationshipInstanceDetail(BaseModel):
     snippet: Optional[str] = Field(
         None, description="Optional text snippet supporting this relationship instance."
     )
-    confidence_score: Optional[float] = Field(
-        None,
-        description="Optional confidence score (0.0 to 1.0) for this relationship instance.",
-    )
-    relevance_score: Optional[float] = Field(
-        None,
-        description="Optional relevance score (0.0 to 1.0) for this relationship instance.",
-    )
-    clarity_score: Optional[float] = Field(
-        None,
-        description="Optional clarity score (0.0 to 1.0) for this relationship instance.",
-    )
+    # scoring fields inherited from ``ScoredModel``
 
 
 class RelationshipInstanceSchema(BaseModel):


### PR DESCRIPTION
## Summary
- create `ScoredModel` mixin with bounded scoring fields
- refactor schema classes to inherit from the mixin
- clean up unused imports in orchestrator

## Testing
- `ruff check .`
- `mypy .`
