### PR TITLE
Add scoring orchestration agent

### DIFF
--- a/graphyte_ai/workflow_agents.py
+++ b/graphyte_ai/workflow_agents.py
@@ -116,6 +116,26 @@ clarity_score_agent = base_scoring_agent.clone(
     output_type=ClarityScoreSchema,
 )
 
+# --- Scoring Orchestration Agent ---
+# Coordinates calling all three scoring agents and outputs the combined DomainSchema.
+scoring_orchestration_agent = Agent(
+    name="ScoringOrchestrationAgent",
+    instructions=(
+        "Obtain confidence, relevance, and clarity scores for the provided domain "
+        "by handing off to the confidence_score_agent, relevance_score_agent, "
+        "and clarity_score_agent. After receiving the scores, combine them with "
+        "the domain value and output ONLY JSON matching DomainSchema."
+    ),
+    model=DEFAULT_MODEL,
+    handoffs=[confidence_score_agent, relevance_score_agent, clarity_score_agent],
+    output_type=DomainSchema,
+)
+
+# Ensure score agents return control to the orchestration agent
+confidence_score_agent.handoffs = [scoring_orchestration_agent]
+relevance_score_agent.handoffs = [scoring_orchestration_agent]
+clarity_score_agent.handoffs = [scoring_orchestration_agent]
+
 # --- Agent 1: Domain Identifier ---
 domain_identifier_agent = Agent(
     name="DomainIdentifierAgent",
@@ -125,27 +145,14 @@ domain_identifier_agent = Agent(
         "Politics, Education, Environment, Business, Lifestyle, Travel, etc. "
         "Focus on the *primary* topic. The 'domain' field must contain a single concise label representing this dominant topic.\n"
         "If several potential domains appear in the text, select the one with the greatest overall coverage.\n"
-        "Call the confidence_score, relevance_score, and clarity_score tools to generate scores before producing the final output.\n"
-        "Output ONLY valid JSON matching the DomainSchema. The result MUST include 'confidence_score', 'relevance_score', and 'clarity_score'."
+        "After determining the domain, transfer_to_scoring_orchestration_agent to obtain confidence, relevance, and clarity scores before producing the final output.\n"
+        "Output ONLY valid JSON matching the DomainSchema once scoring is complete."
     ),
     model=DOMAIN_MODEL,
     output_type=DomainSchema,
     model_settings=ModelSettings(tool_choice="required"),
-    tools=[
-        confidence_score_agent.as_tool(
-            tool_name="confidence_score",
-            tool_description="Evaluate confidence between 0.0 and 1.0",
-        ),
-        relevance_score_agent.as_tool(
-            tool_name="relevance_score",
-            tool_description="Judge relevance between 0.0 and 1.0",
-        ),
-        clarity_score_agent.as_tool(
-            tool_name="clarity_score",
-            tool_description="Assess clarity between 0.0 and 1.0",
-        ),
-    ],
-    handoffs=[],
+    tools=[],
+    handoffs=[scoring_orchestration_agent],
 )
 
 # --- Agent 2: Sub-Domain Identifier ---
@@ -565,6 +572,7 @@ all_agents = {
     "confidence_score": confidence_score_agent,
     "relevance_score": relevance_score_agent,
     "clarity_score": clarity_score_agent,
+    "scoring_orchestration": scoring_orchestration_agent,
     "relationship_identifier": relationship_type_identifier_agent,
     "relationship_instance_extractor": relationship_extractor_agent,
     # Note: Base agent is not typically included here unless used directly


### PR DESCRIPTION
## Summary
- orchestrate domain scoring with a new agent
- route scoring agents back to the orchestration agent
- update domain identifier to handoff to scoring orchestrator
- expose the orchestrator in `all_agents`

## Testing
- `ruff check graphyte_ai/workflow_agents.py`
- `mypy .` *(fails: Library stubs not installed for `requests`, plus override errors in docs)*