### PR TITLE
Add scoring result schema and integrate scoring into domain step

### DIFF
--- a/graphyte_ai/schemas.py
+++ b/graphyte_ai/schemas.py
@@ -62,6 +62,21 @@ class ClarityScoreSchema(BaseModel):
     )
 
 
+# Schema containing all three scoring metrics
+class ScoringResultSchema(BaseModel):
+    """Represents confidence, relevance, and clarity scores."""
+
+    confidence_score: float = Field(
+        description="Confidence score between 0.0 and 1.0.",
+    )
+    relevance_score: float = Field(
+        description="Relevance score between 0.0 and 1.0.",
+    )
+    clarity_score: float = Field(
+        description="Clarity score between 0.0 and 1.0.",
+    )
+
+
 # Nested schema for a sub-domain
 class SubDomainDetail(BaseModel):
     """Represents a single identified sub-domain."""

--- a/graphyte_ai/workflow_agents.py
+++ b/graphyte_ai/workflow_agents.py
@@ -2,7 +2,7 @@
 from typing import Any
 
 try:
-    from agents import Agent  # type: ignore[attr-defined]
+    from agents import Agent, ModelSettings  # type: ignore[attr-defined]
 except ImportError:
     print("Error: 'agents' SDK library not found or incomplete. Cannot define agents.")
     # Depending on execution context, might want `sys.exit(1)` here,
@@ -32,6 +32,7 @@ from .schemas import (
     ConfidenceScoreSchema,
     RelevanceScoreSchema,
     ClarityScoreSchema,
+    ScoringResultSchema,
 )
 from .config import (
     DOMAIN_MODEL,
@@ -116,18 +117,18 @@ clarity_score_agent = base_scoring_agent.clone(
 )
 
 # --- Scoring Orchestration Agent ---
-# Coordinates calling all three scoring agents and outputs the combined DomainSchema.
+# Coordinates calling all three scoring agents and outputs the combined scoring result.
 scoring_orchestration_agent = Agent(
     name="ScoringOrchestrationAgent",
     instructions=(
         "Obtain confidence, relevance, and clarity scores for the provided domain "
         "by handing off to the confidence_score_agent, relevance_score_agent, "
-        "and clarity_score_agent. After receiving the scores, combine them with "
-        "the domain value and output ONLY JSON matching DomainSchema."
+        "and clarity_score_agent. After receiving the scores, output ONLY JSON "
+        "matching the ScoringResultSchema."
     ),
     model=DEFAULT_MODEL,
     handoffs=[confidence_score_agent, relevance_score_agent, clarity_score_agent],
-    output_type=DomainSchema,
+    output_type=ScoringResultSchema,
 )
 
 # Ensure score agents return control to the orchestration agent

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,3 +3,4 @@ ignore_missing_imports = True
 namespace_packages = True
 explicit_package_bases = True
 disable_error_code = attr-defined
+exclude = graphyte_ai/agent-sdk-docs-examples


### PR DESCRIPTION
## Summary
- add `ScoringResultSchema` in `schemas.py`
- update `scoring_orchestration_agent` to output `ScoringResultSchema`
- fetch scores in `step1_domain.identify_domain`
- exclude docs from mypy checking

## Testing
- `ruff check graphyte_ai/schemas.py graphyte_ai/workflow_agents.py graphyte_ai/steps/step1_domain.py`
- `mypy .`
