### PR TITLE
Fix scoring tool choice persistence

### DIFF
--- a/graphyte_ai/workflow_agents.py
+++ b/graphyte_ai/workflow_agents.py
@@ -140,6 +140,11 @@ scoring_orchestration_agent = Agent(
     model_settings=ModelSettings(tool_choice="required"),
 )
 
+# Prevent the framework from automatically resetting `tool_choice` back to
+# "auto" after each handoff so that the scoring orchestration agent continues
+# forcing tool usage until all three scoring agents have been called.
+scoring_orchestration_agent.reset_tool_choice = False
+
 # Ensure score agents return control to the orchestration agent
 confidence_score_agent.handoffs = [scoring_orchestration_agent]
 relevance_score_agent.handoffs = [scoring_orchestration_agent]


### PR DESCRIPTION
## Summary
- keep `tool_choice="required"` for the scoring orchestration agent across handoffs

## Testing
- `black graphyte_ai/workflow_agents.py`
- `ruff check graphyte_ai/workflow_agents.py`
- `mypy graphyte_ai/workflow_agents.py`
