### PR TITLE
Refactor Domain schema

### DIFF
--- a/graphyte_ai/orchestrator.py
+++ b/graphyte_ai/orchestrator.py
@@ -46,6 +46,7 @@ from .config import (  # noqa: E402
     AGENT_TRACE_BASE_URL,
 )
 from .schemas import (  # noqa: E402
+    DomainResultSchema,  # noqa: F401 - used in step1 output typing
     EntityTypeSchema,
     OntologyTypeSchema,
     EventTypeSchema,

--- a/graphyte_ai/schemas.py
+++ b/graphyte_ai/schemas.py
@@ -4,9 +4,9 @@ from pydantic import BaseModel, Field
 # --- Schemas for Existing Agents (1-3) ---
 
 
-# Schema for primary domain output (Agent 1)
+# Schema for the primary domain identifier
 class DomainSchema(BaseModel):
-    """Schema defining the expected output: the primary domain."""
+    """Schema containing only the identified domain."""
 
     domain: str = Field(
         description=(
@@ -14,6 +14,11 @@ class DomainSchema(BaseModel):
             "(e.g., Technology, Finance, Healthcare, Arts, Science, Entertainment, Sports, Politics)."
         )
     )
+
+
+# Schema for primary domain output with scoring (Agent 1)
+class DomainResultSchema(DomainSchema):
+    """Schema defining the domain result along with optional scores."""
 
     confidence_score: Optional[float] = Field(
         None,

--- a/graphyte_ai/workflow_agents.py
+++ b/graphyte_ai/workflow_agents.py
@@ -10,7 +10,7 @@ except ImportError:
     Agent = Any  # type: ignore[misc]
 
 from .schemas import (
-    DomainSchema,
+    DomainResultSchema,
     SubDomainSchema,
     SingleSubDomainTopicSchema,
     EntityTypeSchema,
@@ -124,10 +124,10 @@ domain_identifier_agent = Agent(
         "Politics, Education, Environment, Business, Lifestyle, Travel, etc. "
         "Focus on the *primary* topic. The 'domain' field must contain a single concise label representing this dominant topic.\n"
         "If several potential domains appear in the text, select the one with the greatest overall coverage.\n"
-        "Output ONLY valid JSON matching the DomainSchema."
+        "Output ONLY valid JSON matching the DomainResultSchema."
     ),
     model=DOMAIN_MODEL,
-    output_type=DomainSchema,
+    output_type=DomainResultSchema,
     tools=[],
     handoffs=[],
 )


### PR DESCRIPTION
## Summary
- split the original `DomainSchema` into `DomainSchema` and `DomainResultSchema`
- update workflow agent and step1 to use `DomainResultSchema`
- add schema import update in orchestrator

## Testing
- `ruff check graphyte_ai`
- `mypy graphyte_ai` *(fails: Library stubs not installed for `requests`)*