### PR TITLE
feat: add result agent helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ dot -Tpng outputs/00_visualization/agent_workflow_graph.gv -o workflow.png
 * **API Keys:** Provide necessary API keys in the `.env` file.
 * **Output Directories:** Output JSON files for each step are saved in the `outputs/` directory by default.
 * **(Advanced):** Modify agent prompts and schemas in the `workflow_agents.py` and `schemas.py` files for domain-specific tuning.
+* **(Advanced):** Wrap identifier agents with `create_result_agent` in `workflow_agents.py` to emit result schemas using pre-computed scores.
 * **(Advanced):** Configure target Knowledge Graph connection details for the final integration step (implementation specific).
 
 ## Use Cases

--- a/graphyte_ai/orchestrator.py
+++ b/graphyte_ai/orchestrator.py
@@ -3,6 +3,9 @@
 This module coordinates the workflow between different agent steps and handles tracing.
 """
 
+# ruff: noqa: E402
+
+
 import asyncio  # Added for gather
 import json
 import logging


### PR DESCRIPTION
## Summary
- add `create_result_agent` helper to streamline result agent creation
- refactor `DomainResultAgent` to use the helper
- document helper usage in README
- silence ruff E402 warnings in `orchestrator.py`

## Testing
- `ruff check graphyte_ai/orchestrator.py graphyte_ai/workflow_agents.py`
- `mypy graphyte_ai/workflow_agents.py graphyte_ai/orchestrator.py`