### PR TITLE
Rename Step 5 entity instances to 5a

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ The workflow progresses through several key phases:
 2.  **Type Identification (Step 4 - Parallel):**
     * Leverages the established context to identify various conceptual **Types**...
 
-3.  **Instance Extraction (Step 5 - Parallel):**
+3.  **Instance Extraction (Steps 5a-5g - Parallel):**
     * Extracts specific **Instances** or mentions...
     * After **relationship instance extraction (Step 6b)**, these results are aggregated into a unified `ExtractedInstances` node for later steps. The aggregated output now includes relationship instances.
 

--- a/graphyte_ai/config.py
+++ b/graphyte_ai/config.py
@@ -57,7 +57,7 @@ MEASUREMENT_TYPE_OUTPUT_DIR = OUTPUTS_DIR_BASE / "04f_measurement_type_identifie
 MODALITY_TYPE_OUTPUT_DIR = (
     OUTPUTS_DIR_BASE / "04g_modality_type_identifier"
 )  # Added directory for new agent (4g)
-ENTITY_INSTANCE_OUTPUT_DIR = OUTPUTS_DIR_BASE / "05_entity_instance_extractor"
+ENTITY_INSTANCE_OUTPUT_DIR = OUTPUTS_DIR_BASE / "05a_entity_instance_extractor"
 ONTOLOGY_INSTANCE_OUTPUT_DIR = OUTPUTS_DIR_BASE / "05b_ontology_instance_extractor"
 EVENT_INSTANCE_OUTPUT_DIR = OUTPUTS_DIR_BASE / "05c_event_instance_extractor"
 STATEMENT_INSTANCE_OUTPUT_DIR = OUTPUTS_DIR_BASE / "05d_statement_instance_extractor"

--- a/graphyte_ai/orchestrator.py
+++ b/graphyte_ai/orchestrator.py
@@ -504,7 +504,7 @@ async def run_combined_workflow(content: str) -> None:
                 )
                 print("Skipping Step 4 (Parallel ID) due to missing prior results.")
 
-            # === Step 5: Extract Specific Entity Instances ===
+            # === Step 5a: Extract Specific Entity Instances ===
             instance_data = (
                 await identify_entity_instances(
                     content,
@@ -680,7 +680,7 @@ async def run_combined_workflow(content: str) -> None:
                 f"Step 4g (Modality Types) Result: {'Success' if modality_data else 'Failed/Skipped/Error'}"
             )  # Added log for new step (4g)
             logger.info(
-                f"Step 5 (Entity Instances) Result: {'Success' if instance_data else 'Failed/Skipped'}"
+                f"Step 5a (Entity Instances) Result: {'Success' if instance_data else 'Failed/Skipped'}"
             )
             logger.info(
                 f"Step 5b (Ontology Instances) Result: {'Success' if ontology_instance_data else 'Failed/Skipped'}"

--- a/graphyte_ai/schemas.py
+++ b/graphyte_ai/schemas.py
@@ -450,7 +450,7 @@ class ModalityTypeSchema(BaseModel):
     )
 
 
-# --- Schema for Step 5: Entity Instance Extraction ---
+# --- Schema for Step 5a: Entity Instance Extraction ---
 
 
 class EntityInstanceDetail(BaseModel):
@@ -936,7 +936,7 @@ class RelationshipInstanceSchema(BaseModel):
 
 # --- Aggregated Extracted Instances Schema ---
 class ExtractedInstancesSchema(BaseModel):
-    """Aggregates all instance extraction outputs from Step 5."""
+    """Aggregates all instance extraction outputs from Steps 5a-5g."""
 
     primary_domain: str = Field(
         description="Overall primary domain context for the extracted instances."

--- a/graphyte_ai/steps/__init__.py
+++ b/graphyte_ai/steps/__init__.py
@@ -12,7 +12,7 @@ from .step4f_measurement_types import identify_measurement_types
 from .step4g_modality_types import (
     identify_modality_types,
 )  # Added import for new step (4g)
-from .step5_entity_instances import identify_entity_instances
+from .step5a_entity_instances import identify_entity_instances
 from .step5b_ontology_instances import identify_ontology_instances
 from .step5c_event_instances import identify_event_instances
 from .step5d_statement_instances import identify_statement_instances

--- a/graphyte_ai/steps/step5a_entity_instances.py
+++ b/graphyte_ai/steps/step5a_entity_instances.py
@@ -1,4 +1,4 @@
-"""Step 5: Entity instance extraction functionality."""
+"""Step 5a: Entity instance extraction functionality."""
 
 import logging
 from datetime import datetime, timezone
@@ -35,26 +35,26 @@ async def identify_entity_instances(
 ) -> Optional[EntityInstanceSchema]:
     """Extract specific entity mentions from the text based on context."""
     if not primary_domain or not sub_domain_data or not topic_data or not entity_data:
-        logger.info("Skipping Step 5 because prerequisites were not identified.")
+        logger.info("Skipping Step 5a because prerequisites were not identified.")
         if not primary_domain:
-            print("Skipping Step 5 as primary domain was not identified.")
+            print("Skipping Step 5a as primary domain was not identified.")
         elif not sub_domain_data:
-            print("Skipping Step 5 as sub-domain identification failed.")
+            print("Skipping Step 5a as sub-domain identification failed.")
         elif not topic_data:
-            print("Skipping Step 5 as topic identification failed.")
+            print("Skipping Step 5a as topic identification failed.")
         elif not entity_data:
-            print("Skipping Step 5 as entity type identification failed.")
+            print("Skipping Step 5a as entity type identification failed.")
         return None
 
     logger.info(
-        f"--- Running Step 5: Entity Instance Extraction (Agent: {entity_instance_extractor_agent.name}) ---"
+        f"--- Running Step 5a: Entity Instance Extraction (Agent: {entity_instance_extractor_agent.name}) ---"
     )
     print(
-        f"\n--- Running Step 5: Entity Instance Extraction using model: {ENTITY_INSTANCE_MODEL} ---"
+        f"\n--- Running Step 5a: Entity Instance Extraction using model: {ENTITY_INSTANCE_MODEL} ---"
     )
 
-    step5_metadata_for_trace = {
-        "workflow_step": "5_entity_instance_extraction",
+    step5a_metadata_for_trace = {
+        "workflow_step": "5a_entity_instance_extraction",
         "agent_name": "Entity Instance Extractor",
         "actual_agent": str(entity_instance_extractor_agent.name),
         "primary_domain_input": primary_domain,
@@ -64,10 +64,10 @@ async def identify_entity_instances(
         ),
         "entity_type_count": str(len(entity_data.identified_entities)),
     }
-    step5_run_config = RunConfig(
-        trace_metadata={k: str(v) for k, v in step5_metadata_for_trace.items()}
+    step5a_run_config = RunConfig(
+        trace_metadata={k: str(v) for k, v in step5a_metadata_for_trace.items()}
     )
-    step5_result: Optional[RunResult] = None
+    step5a_result: Optional[RunResult] = None
     instance_data: Optional[EntityInstanceSchema] = None
 
     context_summary_for_prompt = (
@@ -76,7 +76,7 @@ async def identify_entity_instances(
         f"Entity Types Considered: {', '.join(et.entity_type for et in entity_data.identified_entities)}"
     )
 
-    step5_input_list: List[TResponseInputItem] = [
+    step5a_input_list: List[TResponseInputItem] = [
         {
             "role": "user",
             "content": (
@@ -91,14 +91,14 @@ async def identify_entity_instances(
     ]
 
     try:
-        step5_result = await run_agent_with_retry(
+        step5a_result = await run_agent_with_retry(
             agent=entity_instance_extractor_agent,
-            input_data=step5_input_list,
-            config=step5_run_config,
+            input_data=step5a_input_list,
+            config=step5a_run_config,
         )
 
-        if step5_result:
-            potential_output = getattr(step5_result, "final_output", None)
+        if step5a_result:
+            potential_output = getattr(step5a_result, "final_output", None)
             if isinstance(potential_output, EntityInstanceSchema):
                 instance_data = potential_output
             elif isinstance(potential_output, dict):
@@ -108,11 +108,11 @@ async def identify_entity_instances(
                     )
                 except ValidationError as e:
                     logger.warning(
-                        f"Step 5 dict output failed EntityInstanceSchema validation: {e}"
+                        f"Step 5a dict output failed EntityInstanceSchema validation: {e}"
                     )
             else:
                 logger.warning(
-                    f"Step 5 final_output was not EntityInstanceSchema or dict (type: {type(potential_output)})."
+                    f"Step 5a final_output was not EntityInstanceSchema or dict (type: {type(potential_output)})."
                 )
 
             if instance_data and instance_data.identified_instances:
@@ -123,7 +123,7 @@ async def identify_entity_instances(
                         sd.sub_domain for sd in sub_domain_data.identified_sub_domains
                     ]
                 logger.info(
-                    f"Step 5 Result (Structured Instances):\n{instance_data.model_dump_json(indent=2)}"
+                    f"Step 5a Result (Structured Instances):\n{instance_data.model_dump_json(indent=2)}"
                 )
                 print("\n--- Entity Instances Extracted (Structured Output) ---")
                 print(instance_data.model_dump_json(indent=2))
@@ -145,7 +145,7 @@ async def identify_entity_instances(
                     },
                     "trace_information": {
                         "trace_id": overall_trace_id or "N/A",
-                        "notes": f"Generated by {entity_instance_extractor_agent.name} in Step 5 of workflow.",
+                        "notes": f"Generated by {entity_instance_extractor_agent.name} in Step 5a of workflow.",
                     },
                 }
                 save_result = direct_save_json_output(
@@ -158,17 +158,17 @@ async def identify_entity_instances(
                 logger.info(f"Result of saving entity instance output: {save_result}")
             elif instance_data and not instance_data.identified_instances:
                 logger.warning(
-                    "Step 5 completed but identified_instances list is empty."
+                    "Step 5a completed but identified_instances list is empty."
                 )
-                print("\nStep 5 completed, but no entity instances were identified.")
+                print("\nStep 5a completed, but no entity instances were identified.")
             else:
                 logger.error(
-                    "Step 5 FAILED: Could not extract valid EntityInstanceSchema output."
+                    "Step 5a FAILED: Could not extract valid EntityInstanceSchema output."
                 )
-                print("\nError: Failed to extract entity instances in Step 5.")
+                print("\nError: Failed to extract entity instances in Step 5a.")
                 instance_data = None
         else:
-            logger.error("Step 5 FAILED: Runner.run did not return a result.")
+            logger.error("Step 5a FAILED: Runner.run did not return a result.")
             print(
                 "\nError: Failed to get a result from the entity instance extraction step."
             )
@@ -176,18 +176,18 @@ async def identify_entity_instances(
 
     except (ValidationError, TypeError) as e:
         logger.exception(
-            f"Validation or Type error during Step 5 agent run. Error: {e}",
+            f"Validation or Type error during Step 5a agent run. Error: {e}",
             extra={"trace_id": overall_trace_id or "N/A"},
         )
-        print("\nError: A data validation or type issue occurred during Step 5.")
+        print("\nError: A data validation or type issue occurred during Step 5a.")
         print(f"Error details: {e}")
         instance_data = None
     except Exception as e:
         logger.exception(
-            "An unexpected error occurred during Step 5.",
+            "An unexpected error occurred during Step 5a.",
             extra={"trace_id": overall_trace_id or "N/A"},
         )
-        print(f"\nAn unexpected error occurred during Step 5: {type(e).__name__}: {e}")
+        print(f"\nAn unexpected error occurred during Step 5a: {type(e).__name__}: {e}")
         instance_data = None
 
     return instance_data


### PR DESCRIPTION
## Summary
- rename `step5_entity_instances.py` to `step5a_entity_instances.py`
- update exports and config for new naming
- refresh orchestrator comments/logs to mention Step 5a
- document Step 5a in schema docs and README

## Testing
- `black .`
- `ruff check .`
- `mypy .`