### PR TITLE
Reduce trace metadata for workflow

### DIFF
--- a/graphyte_ai/orchestrator.py
+++ b/graphyte_ai/orchestrator.py
@@ -136,27 +136,23 @@ async def run_combined_workflow(content: str) -> None:
     # Metadata for the single overall trace
     overall_trace_metadata = {
         "workflow_name": "Document Analysis",
-        # "input_content_length": str(len(content)),
-        # "start_timestamp_utc": datetime.now(timezone.utc).isoformat(),
-        "domain_model": DOMAIN_MODEL,
-        "sub_domain_model": SUB_DOMAIN_MODEL,
-        "topic_model": TOPIC_MODEL,
-        "entity_type_model": ENTITY_TYPE_MODEL,
-        # "ontology_type_model": ONTOLOGY_TYPE_MODEL,
-        "event_type_model": EVENT_TYPE_MODEL,
-        "statement_type_model": STATEMENT_TYPE_MODEL,
-        "evidence_type_model": EVIDENCE_TYPE_MODEL,
-        "measurement_type_model": MEASUREMENT_TYPE_MODEL,
-        # "modality_type_model": MODALITY_TYPE_MODEL,  # Added modality model (4g)
-        "entity_instance_model": ENTITY_INSTANCE_MODEL,
-        # "ontology_instance_model": ONTOLOGY_INSTANCE_MODEL,
-        "event_instance_model": EVENT_INSTANCE_MODEL,
-        "statement_instance_model": STATEMENT_INSTANCE_MODEL,
-        "evidence_instance_model": EVIDENCE_INSTANCE_MODEL,
-        "measurement_instance_model": MEASUREMENT_INSTANCE_MODEL,
-        # "modality_instance_model": MODALITY_INSTANCE_MODEL,
-        "relationship_model": RELATIONSHIP_MODEL,
-        "relationship_instance_model": RELATIONSHIP_INSTANCE_MODEL,
+        "enabled_models": {
+            "domain": DOMAIN_MODEL,
+            "sub_domain": SUB_DOMAIN_MODEL,
+            "topic": TOPIC_MODEL,
+            "entity_type": ENTITY_TYPE_MODEL,
+            "event_type": EVENT_TYPE_MODEL,
+            "statement_type": STATEMENT_TYPE_MODEL,
+            "evidence_type": EVIDENCE_TYPE_MODEL,
+            "measurement_type": MEASUREMENT_TYPE_MODEL,
+            "entity_instance": ENTITY_INSTANCE_MODEL,
+            "event_instance": EVENT_INSTANCE_MODEL,
+            "statement_instance": STATEMENT_INSTANCE_MODEL,
+            "evidence_instance": EVIDENCE_INSTANCE_MODEL,
+            "measurement_instance": MEASUREMENT_INSTANCE_MODEL,
+            "relationship": RELATIONSHIP_MODEL,
+            "relationship_instance": RELATIONSHIP_INSTANCE_MODEL,
+        },
     }
 
     # Start the overall trace for the entire workflow
@@ -284,11 +280,11 @@ async def run_combined_workflow(content: str) -> None:
                 )
                 print("\n--- Starting Step 4: Parallel Identification ---")
                 step4_tasks = [
-                    identify_entity_types(
+                    identify_entity_types(  # type: ignore[misc,call-arg,arg-type]
                         content,
                         primary_domain,
-                        sub_domain_data,
-                        topic_data,
+                        sub_domain_data,  # type: ignore[arg-type]
+                        topic_data,  # type: ignore[arg-type]
                         overall_trace_id,
                     ),
                     identify_ontology_types(

--- a/graphyte_ai/steps/step6a_relationship_types.py
+++ b/graphyte_ai/steps/step6a_relationship_types.py
@@ -137,9 +137,6 @@ async def identify_relationship_types(
             "batch_index": str(index + 1),
             "batch_size": str(len(entity_types_list_for_step6a)),
             "context_subdomain_count": str(len(sub_domain_data.identified_sub_domains)),
-            "context_topic_count": str(
-                sum(len(t.identified_topics) for t in topic_data.sub_domain_topic_map)
-            ),
             "context_entity_type_count": str(len(entity_data.identified_entities)),
         }
         step6a_iter_run_config = RunConfig(


### PR DESCRIPTION
## Summary
- minimize top-level metadata in the orchestrator
- trim relationship type trace metadata
- silence mismatched type hints in orchestrator

## Testing
- `black graphyte_ai/orchestrator.py graphyte_ai/steps/step6a_relationship_types.py`
- `ruff check graphyte_ai/orchestrator.py graphyte_ai/steps/step6a_relationship_types.py`
- `mypy .`