### PR TITLE
Add slug helper and per-domain tracing

### DIFF
--- a/graphyte_ai/steps/step3_topics.py
+++ b/graphyte_ai/steps/step3_topics.py
@@ -7,12 +7,22 @@ from typing import List, Optional
 
 from pydantic import ValidationError
 
-from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
+from agents import (
+    RunConfig,
+    RunResult,
+    TResponseInputItem,
+    gen_trace_id,
+)  # type: ignore[attr-defined]
 
 from ..workflow_agents import topic_identifier_agent, topic_result_agent
 from ..config import TOPIC_MODEL, TOPIC_OUTPUT_DIR, TOPIC_OUTPUT_FILENAME
 from ..schemas import TopicSchema, SingleSubDomainTopicSchema, SubDomainSchema
-from ..utils import direct_save_json_output, run_agent_with_retry, score_topics
+from ..utils import (
+    direct_save_json_output,
+    run_agent_with_retry,
+    score_topics,
+    slugify,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +72,8 @@ async def identify_topics(
     topic_tasks = []
     sub_domains_being_processed = (
         []
-    )  # Keep track of which sub-domain corresponds to which task/result
+    )  # Keep track of which sub-domain corresponds to each task
+    sub_domain_trace_map: dict[str, str] = {}
     aggregated_topic_results: List[SingleSubDomainTopicSchema] = []
 
     # --- Prepare tasks for parallel execution ---
@@ -76,6 +87,9 @@ async def identify_topics(
         logger.debug(
             f"Preparing task for Step 3 ({index+1}/{len(sub_domains_list_for_step3)}): Sub-Domain '{current_sub_domain}'"
         )
+
+        slug = slugify(current_sub_domain)
+        step3_iter_trace_id = gen_trace_id()
 
         display_sub_domain = (
             (current_sub_domain[:25] + "...")
@@ -92,13 +106,15 @@ async def identify_topics(
             "batch_size": str(len(sub_domains_list_for_step3)),
         }
         step3_iter_run_config = RunConfig(
-            workflow_name="step3_topics",
-            trace_id=trace_id,
+            workflow_name=f"step3_topics_{slug}",
+            trace_id=step3_iter_trace_id,
             group_id=group_id,
             trace_metadata={
                 k: str(v) for k, v in step3_iter_metadata_for_trace.items()
             },
         )
+
+        sub_domain_trace_map[current_sub_domain] = step3_iter_trace_id
 
         step3_iter_input_list: List[TResponseInputItem] = [
             {
@@ -326,6 +342,7 @@ async def identify_topics(
             "sub_domains_successfully_processed": [
                 item.sub_domain for item in aggregated_topic_results
             ],
+            "trace_ids_per_sub_domain": sub_domain_trace_map,
             "sub_domain_input_source": "List extracted from Step 2 output (SubDomainSchema)",
             "execution_mode": "Parallel (asyncio.gather)",
             "model_used_per_topic_call": TOPIC_MODEL,

--- a/graphyte_ai/utils.py
+++ b/graphyte_ai/utils.py
@@ -3,6 +3,7 @@ import asyncio
 import json
 import logging
 import sys
+import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union, cast
 
@@ -271,6 +272,16 @@ def prompt_user_for_input() -> str:
         print("\nInput cancelled by user.")
         logger.warning("Stdin input cancelled by user.")
         return ""
+
+
+def slugify(text: str, max_length: Optional[int] = None) -> str:
+    """Convert text to a filesystem-friendly slug."""
+
+    slug = re.sub(r"[^a-z0-9]+", "_", text.lower())
+    slug = re.sub(r"_{2,}", "_", slug).strip("_")
+    if max_length and max_length > 0:
+        slug = slug[:max_length].rstrip("_")
+    return slug
 
 
 # --- Helper Function to Save JSON Output ---


### PR DESCRIPTION
## Summary
- add a `slugify` helper for safe names
- generate a trace ID for each Step 3 sub-domain task
- include these trace IDs in the analysis details

## Testing
- `black graphyte_ai/utils.py graphyte_ai/steps/step3_topics.py`
- `ruff check graphyte_ai/utils.py graphyte_ai/steps/step3_topics.py`
- `mypy .`
