### PR TITLE
Add scoring helpers for step4 analyses

### DIFF
--- a/graphyte_ai/steps/step4a_entity_types.py
+++ b/graphyte_ai/steps/step4a_entity_types.py
@@ -18,7 +18,11 @@ from ..schemas import (
     SingleSubDomainTopicSchema,
     SingleSubDomainEntityTypeSchema,
 )
-from ..utils import direct_save_json_output, run_agent_with_retry
+from ..utils import (
+    direct_save_json_output,
+    run_agent_with_retry,
+    score_entity_types,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -136,6 +140,8 @@ async def identify_entity_types(
                     entity_data.sub_domain = topic_info.sub_domain
                     # If strict matching is needed, correct it:
                     # entity_data.analyzed_sub_domains = [sd.sub_domain for sd in sub_domain_data.identified_sub_domains]
+
+                entity_data = await score_entity_types(entity_data, content)
 
                 # Log and print results
                 entity_log_items = [

--- a/graphyte_ai/steps/step4b_ontology_types.py
+++ b/graphyte_ai/steps/step4b_ontology_types.py
@@ -15,7 +15,11 @@ from ..config import (
     ONTOLOGY_TYPE_OUTPUT_FILENAME,
 )
 from ..schemas import OntologyTypeSchema, SubDomainSchema, TopicSchema
-from ..utils import direct_save_json_output, run_agent_with_retry
+from ..utils import (
+    direct_save_json_output,
+    run_agent_with_retry,
+    score_ontology_types,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -147,6 +151,8 @@ async def identify_ontology_types(
                     logger.warning(
                         f"Analyzed sub-domains in Step 4b output {ontology_data.analyzed_sub_domains} differs from Step 2 input { [sd.sub_domain for sd in sub_domain_data.identified_sub_domains]}. Using Step 4b's list."
                     )
+
+                ontology_data = await score_ontology_types(ontology_data, content)
 
                 # Log and print results
                 ontology_log_items = [

--- a/graphyte_ai/steps/step4c_event_types.py
+++ b/graphyte_ai/steps/step4c_event_types.py
@@ -19,7 +19,11 @@ from ..schemas import (
     SubDomainSchema,
     TopicSchema,
 )  # Import new output schema
-from ..utils import direct_save_json_output, run_agent_with_retry
+from ..utils import (
+    direct_save_json_output,
+    run_agent_with_retry,
+    score_event_types,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -145,6 +149,8 @@ async def identify_event_types(
                     logger.warning(
                         f"Analyzed sub-domains in Step 4c output {event_data.analyzed_sub_domains} differs from Step 2 input { [sd.sub_domain for sd in sub_domain_data.identified_sub_domains]}. Using Step 4c's list."
                     )
+
+                event_data = await score_event_types(event_data, content)
 
                 # Log and print results
                 event_log_items = [

--- a/graphyte_ai/steps/step4d_statement_types.py
+++ b/graphyte_ai/steps/step4d_statement_types.py
@@ -24,7 +24,11 @@ from ..schemas import (
     SubDomainSchema,
     TopicSchema,
 )  # Import new output schema
-from ..utils import direct_save_json_output, run_agent_with_retry
+from ..utils import (
+    direct_save_json_output,
+    run_agent_with_retry,
+    score_statement_types,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -154,6 +158,8 @@ async def identify_statement_types(
                     logger.warning(
                         f"Analyzed sub-domains in Step 4d output {statement_data.analyzed_sub_domains} differs from Step 2 input { [sd.sub_domain for sd in sub_domain_data.identified_sub_domains]}. Using Step 4d's list."
                     )
+
+                statement_data = await score_statement_types(statement_data, content)
 
                 # Log and print results
                 statement_log_items = [

--- a/graphyte_ai/steps/step4e_evidence_types.py
+++ b/graphyte_ai/steps/step4e_evidence_types.py
@@ -24,7 +24,11 @@ from ..schemas import (
     SubDomainSchema,
     TopicSchema,
 )  # Import new output schema
-from ..utils import direct_save_json_output, run_agent_with_retry
+from ..utils import (
+    direct_save_json_output,
+    run_agent_with_retry,
+    score_evidence_types,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -154,6 +158,8 @@ async def identify_evidence_types(
                     logger.warning(
                         f"Analyzed sub-domains in Step 4e output {evidence_data.analyzed_sub_domains} differs from Step 2 input { [sd.sub_domain for sd in sub_domain_data.identified_sub_domains]}. Using Step 4e's list."
                     )
+
+                evidence_data = await score_evidence_types(evidence_data, content)
 
                 # Log and print results
                 evidence_log_items = [

--- a/graphyte_ai/steps/step4f_measurement_types.py
+++ b/graphyte_ai/steps/step4f_measurement_types.py
@@ -24,7 +24,11 @@ from ..schemas import (
     SubDomainSchema,
     TopicSchema,
 )  # Import new output schema
-from ..utils import direct_save_json_output, run_agent_with_retry
+from ..utils import (
+    direct_save_json_output,
+    run_agent_with_retry,
+    score_measurement_types,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -154,6 +158,10 @@ async def identify_measurement_types(
                     logger.warning(
                         f"Analyzed sub-domains in Step 4f output {measurement_data.analyzed_sub_domains} differs from Step 2 input { [sd.sub_domain for sd in sub_domain_data.identified_sub_domains]}. Using Step 4f's list."
                     )
+
+                measurement_data = await score_measurement_types(
+                    measurement_data, content
+                )
 
                 # Log and print results
                 measurement_log_items = [

--- a/graphyte_ai/steps/step4g_modality_types.py
+++ b/graphyte_ai/steps/step4g_modality_types.py
@@ -24,7 +24,11 @@ from ..schemas import (
     SubDomainSchema,
     TopicSchema,
 )  # Import new output schema
-from ..utils import direct_save_json_output, run_agent_with_retry
+from ..utils import (
+    direct_save_json_output,
+    run_agent_with_retry,
+    score_modality_types,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -154,6 +158,8 @@ async def identify_modality_types(
                     logger.warning(
                         f"Analyzed sub-domains in Step 4g output {modality_data.analyzed_sub_domains} differs from Step 2 input { [sd.sub_domain for sd in sub_domain_data.identified_sub_domains]}. Using Step 4g's list."
                     )
+
+                modality_data = await score_modality_types(modality_data, content)
 
                 # Log and print results
                 modality_log_items = [

--- a/graphyte_ai/utils.py
+++ b/graphyte_ai/utils.py
@@ -60,6 +60,13 @@ from .schemas import (
     SubDomainSchema,
     TopicSchema,
     TopicDetail,
+    SingleSubDomainEntityTypeSchema,
+    OntologyTypeSchema,
+    EventTypeSchema,
+    StatementTypeSchema,
+    EvidenceTypeSchema,
+    MeasurementTypeSchema,
+    ModalityTypeSchema,
 )
 
 # Get logger for utils module
@@ -574,3 +581,264 @@ async def score_topics(topic_data: TopicSchema, context_text: str) -> TopicSchem
         item.clarity_score = clar_data.clarity_score if clar_data else None
 
     return topic_data
+
+
+async def score_entity_types(
+    entity_data: SingleSubDomainEntityTypeSchema, context_text: str
+) -> SingleSubDomainEntityTypeSchema:
+    """Score each entity type within ``entity_data``.
+
+    Parameters
+    ----------
+    entity_data:
+        The entity type analysis output for a single sub-domain.
+    context_text:
+        The original text content used for scoring.
+
+    Returns
+    -------
+    SingleSubDomainEntityTypeSchema
+        The updated schema with scores populated on each entity type.
+    """
+
+    tasks = [
+        run_parallel_scoring(item.entity_type, context_text)
+        for item in entity_data.identified_entities
+    ]
+
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    for item, result in zip(entity_data.identified_entities, results):
+        if isinstance(result, Exception):
+            logger.error(
+                "Scoring failed for entity type '%s'", item.entity_type, exc_info=result
+            )
+            continue
+
+        conf_data, rel_data, clar_data = cast(
+            tuple[
+                Optional[ConfidenceScoreSchema],
+                Optional[RelevanceScoreSchema],
+                Optional[ClarityScoreSchema],
+            ],
+            result,
+        )
+        item.confidence_score = conf_data.confidence_score if conf_data else None
+        item.relevance_score = rel_data.relevance_score if rel_data else None
+        item.clarity_score = clar_data.clarity_score if clar_data else None
+
+    return entity_data
+
+
+async def score_ontology_types(
+    ontology_data: OntologyTypeSchema, context_text: str
+) -> OntologyTypeSchema:
+    """Score each ontology type within ``ontology_data``."""
+
+    tasks = [
+        run_parallel_scoring(item.ontology_type, context_text)
+        for item in ontology_data.identified_ontology_types
+    ]
+
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    for item, result in zip(ontology_data.identified_ontology_types, results):
+        if isinstance(result, Exception):
+            logger.error(
+                "Scoring failed for ontology type '%s'",
+                item.ontology_type,
+                exc_info=result,
+            )
+            continue
+
+        conf_data, rel_data, clar_data = cast(
+            tuple[
+                Optional[ConfidenceScoreSchema],
+                Optional[RelevanceScoreSchema],
+                Optional[ClarityScoreSchema],
+            ],
+            result,
+        )
+        item.confidence_score = conf_data.confidence_score if conf_data else None
+        item.relevance_score = rel_data.relevance_score if rel_data else None
+        item.clarity_score = clar_data.clarity_score if clar_data else None
+
+    return ontology_data
+
+
+async def score_event_types(
+    event_data: EventTypeSchema, context_text: str
+) -> EventTypeSchema:
+    """Score each event type within ``event_data``."""
+
+    tasks = [
+        run_parallel_scoring(item.event_type, context_text)
+        for item in event_data.identified_events
+    ]
+
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    for item, result in zip(event_data.identified_events, results):
+        if isinstance(result, Exception):
+            logger.error(
+                "Scoring failed for event type '%s'", item.event_type, exc_info=result
+            )
+            continue
+
+        conf_data, rel_data, clar_data = cast(
+            tuple[
+                Optional[ConfidenceScoreSchema],
+                Optional[RelevanceScoreSchema],
+                Optional[ClarityScoreSchema],
+            ],
+            result,
+        )
+        item.confidence_score = conf_data.confidence_score if conf_data else None
+        item.relevance_score = rel_data.relevance_score if rel_data else None
+        item.clarity_score = clar_data.clarity_score if clar_data else None
+
+    return event_data
+
+
+async def score_statement_types(
+    statement_data: StatementTypeSchema, context_text: str
+) -> StatementTypeSchema:
+    """Score each statement type within ``statement_data``."""
+
+    tasks = [
+        run_parallel_scoring(item.statement_type, context_text)
+        for item in statement_data.identified_statements
+    ]
+
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    for item, result in zip(statement_data.identified_statements, results):
+        if isinstance(result, Exception):
+            logger.error(
+                "Scoring failed for statement type '%s'",
+                item.statement_type,
+                exc_info=result,
+            )
+            continue
+
+        conf_data, rel_data, clar_data = cast(
+            tuple[
+                Optional[ConfidenceScoreSchema],
+                Optional[RelevanceScoreSchema],
+                Optional[ClarityScoreSchema],
+            ],
+            result,
+        )
+        item.confidence_score = conf_data.confidence_score if conf_data else None
+        item.relevance_score = rel_data.relevance_score if rel_data else None
+        item.clarity_score = clar_data.clarity_score if clar_data else None
+
+    return statement_data
+
+
+async def score_evidence_types(
+    evidence_data: EvidenceTypeSchema, context_text: str
+) -> EvidenceTypeSchema:
+    """Score each evidence type within ``evidence_data``."""
+
+    tasks = [
+        run_parallel_scoring(item.evidence_type, context_text)
+        for item in evidence_data.identified_evidence
+    ]
+
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    for item, result in zip(evidence_data.identified_evidence, results):
+        if isinstance(result, Exception):
+            logger.error(
+                "Scoring failed for evidence type '%s'",
+                item.evidence_type,
+                exc_info=result,
+            )
+            continue
+
+        conf_data, rel_data, clar_data = cast(
+            tuple[
+                Optional[ConfidenceScoreSchema],
+                Optional[RelevanceScoreSchema],
+                Optional[ClarityScoreSchema],
+            ],
+            result,
+        )
+        item.confidence_score = conf_data.confidence_score if conf_data else None
+        item.relevance_score = rel_data.relevance_score if rel_data else None
+        item.clarity_score = clar_data.clarity_score if clar_data else None
+
+    return evidence_data
+
+
+async def score_measurement_types(
+    measurement_data: MeasurementTypeSchema, context_text: str
+) -> MeasurementTypeSchema:
+    """Score each measurement type within ``measurement_data``."""
+
+    tasks = [
+        run_parallel_scoring(item.measurement_type, context_text)
+        for item in measurement_data.identified_measurements
+    ]
+
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    for item, result in zip(measurement_data.identified_measurements, results):
+        if isinstance(result, Exception):
+            logger.error(
+                "Scoring failed for measurement type '%s'",
+                item.measurement_type,
+                exc_info=result,
+            )
+            continue
+
+        conf_data, rel_data, clar_data = cast(
+            tuple[
+                Optional[ConfidenceScoreSchema],
+                Optional[RelevanceScoreSchema],
+                Optional[ClarityScoreSchema],
+            ],
+            result,
+        )
+        item.confidence_score = conf_data.confidence_score if conf_data else None
+        item.relevance_score = rel_data.relevance_score if rel_data else None
+        item.clarity_score = clar_data.clarity_score if clar_data else None
+
+    return measurement_data
+
+
+async def score_modality_types(
+    modality_data: ModalityTypeSchema, context_text: str
+) -> ModalityTypeSchema:
+    """Score each modality type within ``modality_data``."""
+
+    tasks = [
+        run_parallel_scoring(item.modality_type, context_text)
+        for item in modality_data.identified_modalities
+    ]
+
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    for item, result in zip(modality_data.identified_modalities, results):
+        if isinstance(result, Exception):
+            logger.error(
+                "Scoring failed for modality type '%s'",
+                item.modality_type,
+                exc_info=result,
+            )
+            continue
+
+        conf_data, rel_data, clar_data = cast(
+            tuple[
+                Optional[ConfidenceScoreSchema],
+                Optional[RelevanceScoreSchema],
+                Optional[ClarityScoreSchema],
+            ],
+            result,
+        )
+        item.confidence_score = conf_data.confidence_score if conf_data else None
+        item.relevance_score = rel_data.relevance_score if rel_data else None
+        item.clarity_score = clar_data.clarity_score if clar_data else None
+
+    return modality_data

--- a/graphyte_ai/workflow_agents.py
+++ b/graphyte_ai/workflow_agents.py
@@ -251,8 +251,7 @@ base_type_identifier_instructions_template = (
     "Use this context to assess which {concept_type_singular}s are most relevant to the overall subject matter.\n"
     "For EACH identified {concept_type_singular}, provide:\n"
     "1. The classified {concept_type_singular}.\n"
-    "Call the confidence_score_agent, relevance_score_agent, and clarity_score_agent tools for each candidate before finalizing your list.\n"
-    "Every item MUST include 'confidence_score', 'relevance_score', and 'clarity_score'.\n"
+    "Do **not** include scoring fields such as 'confidence_score', 'relevance_score', or 'clarity_score'.\n"
     "Provide an overall analysis summary if applicable.\n"
     "Output ONLY the result using the provided schema structure. Ensure the {list_field_name} field contains a list of items, each with '{item_field_name}'. Include the 'primary_domain' and 'analyzed_sub_domains' fields from the context in your output schema."
 )
@@ -261,20 +260,7 @@ base_type_identifier_agent = Agent(
     name="BaseTypeIdentifierAgent",  # Generic name, will be overridden
     instructions=base_type_identifier_instructions_template,  # Will be formatted in clones
     # No default model or output_type, must be specified in clones
-    tools=[
-        confidence_score_agent.as_tool(
-            tool_name="confidence_score",
-            tool_description="Evaluate confidence between 0.0 and 1.0",
-        ),
-        relevance_score_agent.as_tool(
-            tool_name="relevance_score",
-            tool_description="Judge relevance between 0.0 and 1.0",
-        ),
-        clarity_score_agent.as_tool(
-            tool_name="clarity_score",
-            tool_description="Assess clarity between 0.0 and 1.0",
-        ),
-    ],
+    tools=[],
     handoffs=[],
 )
 


### PR DESCRIPTION
## Summary
- add scoring utilities for type identification schemas
- update step4 modules to score identified types before saving
- modify type identifier agent instructions and remove scoring tools

## Testing
- `black .`
- `ruff check .`
- `mypy .`
