### PR TITLE
feat: add explicit scoring for instance extraction

### DIFF
--- a/graphyte_ai/steps/step5a_entity_instances.py
+++ b/graphyte_ai/steps/step5a_entity_instances.py
@@ -20,7 +20,11 @@ from ..schemas import (
     TopicSchema,
     EntityTypeSchema,
 )
-from ..utils import direct_save_json_output, run_agent_with_retry
+from ..utils import (
+    direct_save_json_output,
+    run_agent_with_retry,
+    score_entity_instances,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -126,6 +130,7 @@ async def identify_entity_instances(
                     instance_data.analyzed_sub_domains = [
                         sd.sub_domain for sd in sub_domain_data.identified_sub_domains
                     ]
+                instance_data = await score_entity_instances(instance_data, content)
                 logger.info(
                     f"Step 5a Result (Structured Instances):\n{instance_data.model_dump_json(indent=2)}"
                 )

--- a/graphyte_ai/steps/step5b_ontology_instances.py
+++ b/graphyte_ai/steps/step5b_ontology_instances.py
@@ -20,7 +20,11 @@ from ..schemas import (
     TopicSchema,
     OntologyTypeSchema,
 )
-from ..utils import direct_save_json_output, run_agent_with_retry
+from ..utils import (
+    direct_save_json_output,
+    run_agent_with_retry,
+    score_ontology_instances,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -126,6 +130,7 @@ async def identify_ontology_instances(
                     instance_data.analyzed_sub_domains = [
                         sd.sub_domain for sd in sub_domain_data.identified_sub_domains
                     ]
+                instance_data = await score_ontology_instances(instance_data, content)
                 logger.info(
                     f"Step 5b Result (Structured Instances):\n{instance_data.model_dump_json(indent=2)}"
                 )

--- a/graphyte_ai/steps/step5c_event_instances.py
+++ b/graphyte_ai/steps/step5c_event_instances.py
@@ -15,7 +15,11 @@ from ..config import (
     EVENT_INSTANCE_OUTPUT_FILENAME,
 )
 from ..schemas import EventInstanceSchema, SubDomainSchema, TopicSchema, EventTypeSchema
-from ..utils import direct_save_json_output, run_agent_with_retry
+from ..utils import (
+    direct_save_json_output,
+    run_agent_with_retry,
+    score_event_instances,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -119,6 +123,7 @@ async def identify_event_instances(
                     instance_data.analyzed_sub_domains = [
                         sd.sub_domain for sd in sub_domain_data.identified_sub_domains
                     ]
+                instance_data = await score_event_instances(instance_data, content)
                 logger.info(
                     f"Step 5c Result (Structured Instances):\n{instance_data.model_dump_json(indent=2)}"
                 )

--- a/graphyte_ai/steps/step5d_statement_instances.py
+++ b/graphyte_ai/steps/step5d_statement_instances.py
@@ -20,7 +20,11 @@ from ..schemas import (
     TopicSchema,
     StatementTypeSchema,
 )
-from ..utils import direct_save_json_output, run_agent_with_retry
+from ..utils import (
+    direct_save_json_output,
+    run_agent_with_retry,
+    score_statement_instances,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -131,6 +135,7 @@ async def identify_statement_instances(
                     instance_data.analyzed_sub_domains = [
                         sd.sub_domain for sd in sub_domain_data.identified_sub_domains
                     ]
+                instance_data = await score_statement_instances(instance_data, content)
                 logger.info(
                     f"Step 5d Result (Structured Instances):\n{instance_data.model_dump_json(indent=2)}"
                 )

--- a/graphyte_ai/steps/step5e_evidence_instances.py
+++ b/graphyte_ai/steps/step5e_evidence_instances.py
@@ -20,7 +20,11 @@ from ..schemas import (
     TopicSchema,
     EvidenceTypeSchema,
 )
-from ..utils import direct_save_json_output, run_agent_with_retry
+from ..utils import (
+    direct_save_json_output,
+    run_agent_with_retry,
+    score_evidence_instances,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -126,6 +130,7 @@ async def identify_evidence_instances(
                     instance_data.analyzed_sub_domains = [
                         sd.sub_domain for sd in sub_domain_data.identified_sub_domains
                     ]
+                instance_data = await score_evidence_instances(instance_data, content)
                 logger.info(
                     f"Step 5e Result (Structured Instances):\n{instance_data.model_dump_json(indent=2)}"
                 )

--- a/graphyte_ai/steps/step5f_measurement_instances.py
+++ b/graphyte_ai/steps/step5f_measurement_instances.py
@@ -20,7 +20,11 @@ from ..schemas import (
     TopicSchema,
     MeasurementTypeSchema,
 )
-from ..utils import direct_save_json_output, run_agent_with_retry
+from ..utils import (
+    direct_save_json_output,
+    run_agent_with_retry,
+    score_measurement_instances,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -131,6 +135,9 @@ async def identify_measurement_instances(
                     instance_data.analyzed_sub_domains = [
                         sd.sub_domain for sd in sub_domain_data.identified_sub_domains
                     ]
+                instance_data = await score_measurement_instances(
+                    instance_data, content
+                )
                 logger.info(
                     f"Step 5f Result (Structured Instances):\n{instance_data.model_dump_json(indent=2)}"
                 )

--- a/graphyte_ai/steps/step5g_modality_instances.py
+++ b/graphyte_ai/steps/step5g_modality_instances.py
@@ -20,7 +20,11 @@ from ..schemas import (
     TopicSchema,
     ModalityTypeSchema,
 )
-from ..utils import direct_save_json_output, run_agent_with_retry
+from ..utils import (
+    direct_save_json_output,
+    run_agent_with_retry,
+    score_modality_instances,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -126,6 +130,7 @@ async def identify_modality_instances(
                     instance_data.analyzed_sub_domains = [
                         sd.sub_domain for sd in sub_domain_data.identified_sub_domains
                     ]
+                instance_data = await score_modality_instances(instance_data, content)
                 logger.info(
                     f"Step 5g Result (Structured Instances):\n{instance_data.model_dump_json(indent=2)}"
                 )

--- a/graphyte_ai/utils.py
+++ b/graphyte_ai/utils.py
@@ -67,6 +67,13 @@ from .schemas import (
     EvidenceTypeSchema,
     MeasurementTypeSchema,
     ModalityTypeSchema,
+    EntityInstanceSchema,
+    OntologyInstanceSchema,
+    EventInstanceSchema,
+    StatementInstanceSchema,
+    EvidenceInstanceSchema,
+    MeasurementInstanceSchema,
+    ModalityInstanceSchema,
 )
 
 # Get logger for utils module
@@ -842,3 +849,255 @@ async def score_modality_types(
         item.clarity_score = clar_data.clarity_score if clar_data else None
 
     return modality_data
+
+
+async def score_entity_instances(
+    instance_data: EntityInstanceSchema, context_text: str
+) -> EntityInstanceSchema:
+    """Score each entity instance within ``instance_data``."""
+
+    tasks = [
+        run_parallel_scoring(item.text_span, context_text)
+        for item in instance_data.identified_instances
+    ]
+
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    for item, result in zip(instance_data.identified_instances, results):
+        if isinstance(result, Exception):
+            logger.error(
+                "Scoring failed for entity instance '%s'",
+                item.text_span,
+                exc_info=result,
+            )
+            continue
+
+        conf_data, rel_data, clar_data = cast(
+            tuple[
+                Optional[ConfidenceScoreSchema],
+                Optional[RelevanceScoreSchema],
+                Optional[ClarityScoreSchema],
+            ],
+            result,
+        )
+        item.confidence_score = conf_data.confidence_score if conf_data else None
+        item.relevance_score = rel_data.relevance_score if rel_data else None
+        item.clarity_score = clar_data.clarity_score if clar_data else None
+
+    return instance_data
+
+
+async def score_ontology_instances(
+    instance_data: OntologyInstanceSchema, context_text: str
+) -> OntologyInstanceSchema:
+    """Score each ontology instance within ``instance_data``."""
+
+    tasks = [
+        run_parallel_scoring(item.text_span, context_text)
+        for item in instance_data.identified_instances
+    ]
+
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    for item, result in zip(instance_data.identified_instances, results):
+        if isinstance(result, Exception):
+            logger.error(
+                "Scoring failed for ontology instance '%s'",
+                item.text_span,
+                exc_info=result,
+            )
+            continue
+
+        conf_data, rel_data, clar_data = cast(
+            tuple[
+                Optional[ConfidenceScoreSchema],
+                Optional[RelevanceScoreSchema],
+                Optional[ClarityScoreSchema],
+            ],
+            result,
+        )
+        item.confidence_score = conf_data.confidence_score if conf_data else None
+        item.relevance_score = rel_data.relevance_score if rel_data else None
+        item.clarity_score = clar_data.clarity_score if clar_data else None
+
+    return instance_data
+
+
+async def score_event_instances(
+    instance_data: EventInstanceSchema, context_text: str
+) -> EventInstanceSchema:
+    """Score each event instance within ``instance_data``."""
+
+    tasks = [
+        run_parallel_scoring(item.text_span, context_text)
+        for item in instance_data.identified_instances
+    ]
+
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    for item, result in zip(instance_data.identified_instances, results):
+        if isinstance(result, Exception):
+            logger.error(
+                "Scoring failed for event instance '%s'",
+                item.text_span,
+                exc_info=result,
+            )
+            continue
+
+        conf_data, rel_data, clar_data = cast(
+            tuple[
+                Optional[ConfidenceScoreSchema],
+                Optional[RelevanceScoreSchema],
+                Optional[ClarityScoreSchema],
+            ],
+            result,
+        )
+        item.confidence_score = conf_data.confidence_score if conf_data else None
+        item.relevance_score = rel_data.relevance_score if rel_data else None
+        item.clarity_score = clar_data.clarity_score if clar_data else None
+
+    return instance_data
+
+
+async def score_statement_instances(
+    instance_data: StatementInstanceSchema, context_text: str
+) -> StatementInstanceSchema:
+    """Score each statement instance within ``instance_data``."""
+
+    tasks = [
+        run_parallel_scoring(item.text_span, context_text)
+        for item in instance_data.identified_instances
+    ]
+
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    for item, result in zip(instance_data.identified_instances, results):
+        if isinstance(result, Exception):
+            logger.error(
+                "Scoring failed for statement instance '%s'",
+                item.text_span,
+                exc_info=result,
+            )
+            continue
+
+        conf_data, rel_data, clar_data = cast(
+            tuple[
+                Optional[ConfidenceScoreSchema],
+                Optional[RelevanceScoreSchema],
+                Optional[ClarityScoreSchema],
+            ],
+            result,
+        )
+        item.confidence_score = conf_data.confidence_score if conf_data else None
+        item.relevance_score = rel_data.relevance_score if rel_data else None
+        item.clarity_score = clar_data.clarity_score if clar_data else None
+
+    return instance_data
+
+
+async def score_evidence_instances(
+    instance_data: EvidenceInstanceSchema, context_text: str
+) -> EvidenceInstanceSchema:
+    """Score each evidence instance within ``instance_data``."""
+
+    tasks = [
+        run_parallel_scoring(item.text_span, context_text)
+        for item in instance_data.identified_instances
+    ]
+
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    for item, result in zip(instance_data.identified_instances, results):
+        if isinstance(result, Exception):
+            logger.error(
+                "Scoring failed for evidence instance '%s'",
+                item.text_span,
+                exc_info=result,
+            )
+            continue
+
+        conf_data, rel_data, clar_data = cast(
+            tuple[
+                Optional[ConfidenceScoreSchema],
+                Optional[RelevanceScoreSchema],
+                Optional[ClarityScoreSchema],
+            ],
+            result,
+        )
+        item.confidence_score = conf_data.confidence_score if conf_data else None
+        item.relevance_score = rel_data.relevance_score if rel_data else None
+        item.clarity_score = clar_data.clarity_score if clar_data else None
+
+    return instance_data
+
+
+async def score_measurement_instances(
+    instance_data: MeasurementInstanceSchema, context_text: str
+) -> MeasurementInstanceSchema:
+    """Score each measurement instance within ``instance_data``."""
+
+    tasks = [
+        run_parallel_scoring(item.text_span, context_text)
+        for item in instance_data.identified_instances
+    ]
+
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    for item, result in zip(instance_data.identified_instances, results):
+        if isinstance(result, Exception):
+            logger.error(
+                "Scoring failed for measurement instance '%s'",
+                item.text_span,
+                exc_info=result,
+            )
+            continue
+
+        conf_data, rel_data, clar_data = cast(
+            tuple[
+                Optional[ConfidenceScoreSchema],
+                Optional[RelevanceScoreSchema],
+                Optional[ClarityScoreSchema],
+            ],
+            result,
+        )
+        item.confidence_score = conf_data.confidence_score if conf_data else None
+        item.relevance_score = rel_data.relevance_score if rel_data else None
+        item.clarity_score = clar_data.clarity_score if clar_data else None
+
+    return instance_data
+
+
+async def score_modality_instances(
+    instance_data: ModalityInstanceSchema, context_text: str
+) -> ModalityInstanceSchema:
+    """Score each modality instance within ``instance_data``."""
+
+    tasks = [
+        run_parallel_scoring(item.text_span, context_text)
+        for item in instance_data.identified_instances
+    ]
+
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    for item, result in zip(instance_data.identified_instances, results):
+        if isinstance(result, Exception):
+            logger.error(
+                "Scoring failed for modality instance '%s'",
+                item.text_span,
+                exc_info=result,
+            )
+            continue
+
+        conf_data, rel_data, clar_data = cast(
+            tuple[
+                Optional[ConfidenceScoreSchema],
+                Optional[RelevanceScoreSchema],
+                Optional[ClarityScoreSchema],
+            ],
+            result,
+        )
+        item.confidence_score = conf_data.confidence_score if conf_data else None
+        item.relevance_score = rel_data.relevance_score if rel_data else None
+        item.clarity_score = clar_data.clarity_score if clar_data else None
+
+    return instance_data

--- a/graphyte_ai/workflow_agents.py
+++ b/graphyte_ai/workflow_agents.py
@@ -373,8 +373,7 @@ base_instance_extractor_instructions_template = (
     "Extract specific {concept_description} from the provided text. "
     "Use the context of domain, sub-domains, topics and identified {type_list_name} to guide relevance. "
     "For each extracted instance provide the {instance_field} and {span_field}. "
-    "Call the confidence_score_agent, relevance_score_agent, and clarity_score_agent tools for each instance before producing the final output. "
-    "Every item MUST include 'confidence_score', 'relevance_score', and 'clarity_score'. "
+    "Do **not** include scoring fields such as 'confidence_score', 'relevance_score', or 'clarity_score'. "
     "Output ONLY the result using the provided schema structure. "
     "Ensure the '{list_field}' field contains all extracted items and include the 'primary_domain' and 'analyzed_sub_domains' fields from the context."
 )
@@ -382,20 +381,7 @@ base_instance_extractor_instructions_template = (
 base_instance_extractor_agent = Agent(
     name="BaseInstanceExtractorAgent",  # Generic name, overridden in clones
     instructions=base_instance_extractor_instructions_template,  # Formatted in clones
-    tools=[
-        confidence_score_agent.as_tool(
-            tool_name="confidence_score",
-            tool_description="Evaluate confidence between 0.0 and 1.0",
-        ),
-        relevance_score_agent.as_tool(
-            tool_name="relevance_score",
-            tool_description="Judge relevance between 0.0 and 1.0",
-        ),
-        clarity_score_agent.as_tool(
-            tool_name="clarity_score",
-            tool_description="Assess clarity between 0.0 and 1.0",
-        ),
-    ],
+    tools=[],
     handoffs=[],
 )
 


### PR DESCRIPTION
## Summary
- add scoring helpers for all instance schemas
- invoke new scoring in each step5 extraction stage
- remove scoring tools from instance extractor agents
- update extractor instructions to exclude scoring fields

## Testing
- `black graphyte_ai/steps/step5a_entity_instances.py graphyte_ai/steps/step5b_ontology_instances.py graphyte_ai/steps/step5c_event_instances.py graphyte_ai/steps/step5d_statement_instances.py graphyte_ai/steps/step5e_evidence_instances.py graphyte_ai/steps/step5f_measurement_instances.py graphyte_ai/steps/step5g_modality_instances.py graphyte_ai/utils.py graphyte_ai/workflow_agents.py`
- `ruff check .`
- `mypy .`
