### PR TITLE
Add result agents and integrate validation calls

### DIFF
--- a/graphyte_ai/steps/step4b_ontology_types.py
+++ b/graphyte_ai/steps/step4b_ontology_types.py
@@ -2,13 +2,16 @@
 
 import logging
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import List, Optional, cast
 
 from pydantic import ValidationError
 
 from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
 
-from ..workflow_agents import ontology_type_identifier_agent
+from ..workflow_agents import (
+    ontology_type_identifier_agent,
+    ontology_type_result_agent,
+)
 from ..config import (
     ONTOLOGY_TYPE_MODEL,
     ONTOLOGY_TYPE_OUTPUT_DIR,
@@ -137,6 +140,8 @@ async def identify_ontology_types(
                 )
 
             if ontology_data and ontology_data.identified_ontology_types:
+                assert ontology_data is not None
+                ontology_data = cast(OntologyTypeSchema, ontology_data)
                 # Ensure context fields in output schema match expectations
                 if ontology_data.primary_domain != primary_domain:
                     logger.warning(
@@ -153,6 +158,43 @@ async def identify_ontology_types(
                     )
 
                 ontology_data = await score_ontology_types(ontology_data, content)
+
+                scored_result = await run_agent_with_retry(
+                    ontology_type_result_agent,
+                    ontology_data.model_dump_json(),
+                )
+
+                if scored_result:
+                    potential_scored_output = getattr(
+                        scored_result, "final_output", None
+                    )
+                    if isinstance(potential_scored_output, OntologyTypeSchema):
+                        ontology_data = potential_scored_output
+                    elif isinstance(potential_scored_output, dict):
+                        try:
+                            ontology_data = OntologyTypeSchema.model_validate(
+                                potential_scored_output
+                            )
+                        except ValidationError as e:
+                            logger.warning(
+                                "OntologyTypeSchema validation error after scoring: %s",
+                                e,
+                            )
+                            ontology_data = OntologyTypeSchema.model_validate(
+                                ontology_data.model_dump()
+                            )
+                    else:
+                        logger.error(
+                            "Unexpected ontology type result output type: %s",
+                            type(potential_scored_output),
+                        )
+                        ontology_data = OntologyTypeSchema.model_validate(
+                            ontology_data.model_dump()
+                        )
+                else:
+                    ontology_data = OntologyTypeSchema.model_validate(
+                        ontology_data.model_dump()
+                    )
 
                 # Log and print results
                 ontology_log_items = [

--- a/graphyte_ai/steps/step4c_event_types.py
+++ b/graphyte_ai/steps/step4c_event_types.py
@@ -2,13 +2,16 @@
 
 import logging
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import List, Optional, cast
 
 from pydantic import ValidationError
 
 from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
 
-from ..workflow_agents import event_type_identifier_agent  # Import the new agent
+from ..workflow_agents import (
+    event_type_identifier_agent,  # Import the new agent
+    event_type_result_agent,
+)
 from ..config import (
     EVENT_TYPE_MODEL,
     EVENT_TYPE_OUTPUT_DIR,
@@ -137,6 +140,8 @@ async def identify_event_types(
                 )
 
             if event_data and event_data.identified_events:
+                assert event_data is not None
+                event_data = cast(EventTypeSchema, event_data)
                 # Ensure context fields match
                 if event_data.primary_domain != primary_domain:
                     logger.warning(
@@ -151,6 +156,41 @@ async def identify_event_types(
                     )
 
                 event_data = await score_event_types(event_data, content)
+
+                scored_result = await run_agent_with_retry(
+                    event_type_result_agent,
+                    event_data.model_dump_json(),
+                )
+
+                if scored_result:
+                    potential_scored_output = getattr(
+                        scored_result, "final_output", None
+                    )
+                    if isinstance(potential_scored_output, EventTypeSchema):
+                        event_data = potential_scored_output
+                    elif isinstance(potential_scored_output, dict):
+                        try:
+                            event_data = EventTypeSchema.model_validate(
+                                potential_scored_output
+                            )
+                        except ValidationError as e:
+                            logger.warning(
+                                "EventTypeSchema validation error after scoring: %s",
+                                e,
+                            )
+                            event_data = EventTypeSchema.model_validate(
+                                event_data.model_dump()
+                            )
+                    else:
+                        logger.error(
+                            "Unexpected event type result output type: %s",
+                            type(potential_scored_output),
+                        )
+                        event_data = EventTypeSchema.model_validate(
+                            event_data.model_dump()
+                        )
+                else:
+                    event_data = EventTypeSchema.model_validate(event_data.model_dump())
 
                 # Log and print results
                 event_log_items = [

--- a/graphyte_ai/steps/step4d_statement_types.py
+++ b/graphyte_ai/steps/step4d_statement_types.py
@@ -2,7 +2,7 @@
 
 import logging
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import List, Optional, cast
 
 from pydantic import ValidationError
 
@@ -13,7 +13,10 @@ except ImportError:
     print("Error: 'agents' SDK library not found or incomplete for step 4d.")
     raise
 
-from ..workflow_agents import statement_type_identifier_agent  # Import the new agent
+from ..workflow_agents import (
+    statement_type_identifier_agent,  # Import the new agent
+    statement_type_result_agent,
+)
 from ..config import (
     STATEMENT_TYPE_MODEL,
     STATEMENT_TYPE_OUTPUT_DIR,
@@ -146,6 +149,8 @@ async def identify_statement_types(
                 )
 
             if statement_data and statement_data.identified_statements:
+                assert statement_data is not None
+                statement_data = cast(StatementTypeSchema, statement_data)
                 # Ensure context fields match
                 if statement_data.primary_domain != primary_domain:
                     logger.warning(
@@ -160,6 +165,43 @@ async def identify_statement_types(
                     )
 
                 statement_data = await score_statement_types(statement_data, content)
+
+                scored_result = await run_agent_with_retry(
+                    statement_type_result_agent,
+                    statement_data.model_dump_json(),
+                )
+
+                if scored_result:
+                    potential_scored_output = getattr(
+                        scored_result, "final_output", None
+                    )
+                    if isinstance(potential_scored_output, StatementTypeSchema):
+                        statement_data = potential_scored_output
+                    elif isinstance(potential_scored_output, dict):
+                        try:
+                            statement_data = StatementTypeSchema.model_validate(
+                                potential_scored_output
+                            )
+                        except ValidationError as e:
+                            logger.warning(
+                                "StatementTypeSchema validation error after scoring: %s",
+                                e,
+                            )
+                            statement_data = StatementTypeSchema.model_validate(
+                                statement_data.model_dump()
+                            )
+                    else:
+                        logger.error(
+                            "Unexpected statement type result output type: %s",
+                            type(potential_scored_output),
+                        )
+                        statement_data = StatementTypeSchema.model_validate(
+                            statement_data.model_dump()
+                        )
+                else:
+                    statement_data = StatementTypeSchema.model_validate(
+                        statement_data.model_dump()
+                    )
 
                 # Log and print results
                 statement_log_items = [

--- a/graphyte_ai/steps/step4f_measurement_types.py
+++ b/graphyte_ai/steps/step4f_measurement_types.py
@@ -2,7 +2,7 @@
 
 import logging
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import List, Optional, cast
 
 from pydantic import ValidationError
 
@@ -13,7 +13,10 @@ except ImportError:
     print("Error: 'agents' SDK library not found or incomplete for step 4f.")
     raise
 
-from ..workflow_agents import measurement_type_identifier_agent  # Import the new agent
+from ..workflow_agents import (
+    measurement_type_identifier_agent,  # Import the new agent
+    measurement_type_result_agent,
+)
 from ..config import (
     MEASUREMENT_TYPE_MODEL,
     MEASUREMENT_TYPE_OUTPUT_DIR,
@@ -146,6 +149,8 @@ async def identify_measurement_types(
                 )
 
             if measurement_data and measurement_data.identified_measurements:
+                assert measurement_data is not None
+                measurement_data = cast(MeasurementTypeSchema, measurement_data)
                 # Ensure context fields match
                 if measurement_data.primary_domain != primary_domain:
                     logger.warning(
@@ -162,6 +167,43 @@ async def identify_measurement_types(
                 measurement_data = await score_measurement_types(
                     measurement_data, content
                 )
+
+                scored_result = await run_agent_with_retry(
+                    measurement_type_result_agent,
+                    measurement_data.model_dump_json(),
+                )
+
+                if scored_result:
+                    potential_scored_output = getattr(
+                        scored_result, "final_output", None
+                    )
+                    if isinstance(potential_scored_output, MeasurementTypeSchema):
+                        measurement_data = potential_scored_output
+                    elif isinstance(potential_scored_output, dict):
+                        try:
+                            measurement_data = MeasurementTypeSchema.model_validate(
+                                potential_scored_output
+                            )
+                        except ValidationError as e:
+                            logger.warning(
+                                "MeasurementTypeSchema validation error after scoring: %s",
+                                e,
+                            )
+                            measurement_data = MeasurementTypeSchema.model_validate(
+                                measurement_data.model_dump()
+                            )
+                    else:
+                        logger.error(
+                            "Unexpected measurement type result output type: %s",
+                            type(potential_scored_output),
+                        )
+                        measurement_data = MeasurementTypeSchema.model_validate(
+                            measurement_data.model_dump()
+                        )
+                else:
+                    measurement_data = MeasurementTypeSchema.model_validate(
+                        measurement_data.model_dump()
+                    )
 
                 # Log and print results
                 measurement_log_items = [

--- a/graphyte_ai/steps/step4g_modality_types.py
+++ b/graphyte_ai/steps/step4g_modality_types.py
@@ -2,7 +2,7 @@
 
 import logging
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import List, Optional, cast
 
 from pydantic import ValidationError
 
@@ -13,7 +13,10 @@ except ImportError:
     print("Error: 'agents' SDK library not found or incomplete for step 4g.")
     raise
 
-from ..workflow_agents import modality_type_identifier_agent  # Import the new agent
+from ..workflow_agents import (
+    modality_type_identifier_agent,  # Import the new agent
+    modality_type_result_agent,
+)
 from ..config import (
     MODALITY_TYPE_MODEL,
     MODALITY_TYPE_OUTPUT_DIR,
@@ -146,6 +149,8 @@ async def identify_modality_types(
                 )
 
             if modality_data and modality_data.identified_modalities:
+                assert modality_data is not None
+                modality_data = cast(ModalityTypeSchema, modality_data)
                 # Ensure context fields match
                 if modality_data.primary_domain != primary_domain:
                     logger.warning(
@@ -160,6 +165,43 @@ async def identify_modality_types(
                     )
 
                 modality_data = await score_modality_types(modality_data, content)
+
+                scored_result = await run_agent_with_retry(
+                    modality_type_result_agent,
+                    modality_data.model_dump_json(),
+                )
+
+                if scored_result:
+                    potential_scored_output = getattr(
+                        scored_result, "final_output", None
+                    )
+                    if isinstance(potential_scored_output, ModalityTypeSchema):
+                        modality_data = potential_scored_output
+                    elif isinstance(potential_scored_output, dict):
+                        try:
+                            modality_data = ModalityTypeSchema.model_validate(
+                                potential_scored_output
+                            )
+                        except ValidationError as e:
+                            logger.warning(
+                                "ModalityTypeSchema validation error after scoring: %s",
+                                e,
+                            )
+                            modality_data = ModalityTypeSchema.model_validate(
+                                modality_data.model_dump()
+                            )
+                    else:
+                        logger.error(
+                            "Unexpected modality type result output type: %s",
+                            type(potential_scored_output),
+                        )
+                        modality_data = ModalityTypeSchema.model_validate(
+                            modality_data.model_dump()
+                        )
+                else:
+                    modality_data = ModalityTypeSchema.model_validate(
+                        modality_data.model_dump()
+                    )
 
                 # Log and print results
                 modality_log_items = [

--- a/graphyte_ai/steps/step5a_entity_instances.py
+++ b/graphyte_ai/steps/step5a_entity_instances.py
@@ -2,13 +2,16 @@
 
 import logging
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import List, Optional, cast
 
 from pydantic import ValidationError
 
 from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
 
-from ..workflow_agents import entity_instance_extractor_agent
+from ..workflow_agents import (
+    entity_instance_extractor_agent,
+    entity_instance_result_agent,
+)
 from ..config import (
     ENTITY_INSTANCE_MODEL,
     ENTITY_INSTANCE_OUTPUT_DIR,
@@ -124,6 +127,8 @@ async def identify_entity_instances(
                 )
 
             if instance_data and instance_data.identified_instances:
+                assert instance_data is not None
+                instance_data = cast(EntityInstanceSchema, instance_data)
                 if instance_data.primary_domain != primary_domain:
                     instance_data.primary_domain = primary_domain
                 if not set(instance_data.analyzed_sub_domains):
@@ -131,6 +136,44 @@ async def identify_entity_instances(
                         sd.sub_domain for sd in sub_domain_data.identified_sub_domains
                     ]
                 instance_data = await score_entity_instances(instance_data, content)
+
+                scored_result = await run_agent_with_retry(
+                    entity_instance_result_agent,
+                    instance_data.model_dump_json(),
+                )
+
+                if scored_result:
+                    potential_scored_output = getattr(
+                        scored_result, "final_output", None
+                    )
+                    if isinstance(potential_scored_output, EntityInstanceSchema):
+                        instance_data = potential_scored_output
+                    elif isinstance(potential_scored_output, dict):
+                        try:
+                            instance_data = EntityInstanceSchema.model_validate(
+                                potential_scored_output
+                            )
+                        except ValidationError as e:
+                            logger.warning(
+                                "EntityInstanceSchema validation error after scoring: %s",
+                                e,
+                            )
+                            instance_data = EntityInstanceSchema.model_validate(
+                                instance_data.model_dump()
+                            )
+                    else:
+                        logger.error(
+                            "Unexpected entity instance result output type: %s",
+                            type(potential_scored_output),
+                        )
+                        instance_data = EntityInstanceSchema.model_validate(
+                            instance_data.model_dump()
+                        )
+                else:
+                    instance_data = EntityInstanceSchema.model_validate(
+                        instance_data.model_dump()
+                    )
+
                 logger.info(
                     f"Step 5a Result (Structured Instances):\n{instance_data.model_dump_json(indent=2)}"
                 )

--- a/graphyte_ai/steps/step5b_ontology_instances.py
+++ b/graphyte_ai/steps/step5b_ontology_instances.py
@@ -2,13 +2,16 @@
 
 import logging
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import List, Optional, cast
 
 from pydantic import ValidationError
 
 from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
 
-from ..workflow_agents import ontology_instance_extractor_agent
+from ..workflow_agents import (
+    ontology_instance_extractor_agent,
+    ontology_instance_result_agent,
+)
 from ..config import (
     ONTOLOGY_INSTANCE_MODEL,
     ONTOLOGY_INSTANCE_OUTPUT_DIR,
@@ -124,6 +127,8 @@ async def identify_ontology_instances(
                 )
 
             if instance_data and instance_data.identified_instances:
+                assert instance_data is not None
+                instance_data = cast(OntologyInstanceSchema, instance_data)
                 if instance_data.primary_domain != primary_domain:
                     instance_data.primary_domain = primary_domain
                 if not set(instance_data.analyzed_sub_domains):
@@ -131,6 +136,44 @@ async def identify_ontology_instances(
                         sd.sub_domain for sd in sub_domain_data.identified_sub_domains
                     ]
                 instance_data = await score_ontology_instances(instance_data, content)
+
+                scored_result = await run_agent_with_retry(
+                    ontology_instance_result_agent,
+                    instance_data.model_dump_json(),
+                )
+
+                if scored_result:
+                    potential_scored_output = getattr(
+                        scored_result, "final_output", None
+                    )
+                    if isinstance(potential_scored_output, OntologyInstanceSchema):
+                        instance_data = potential_scored_output
+                    elif isinstance(potential_scored_output, dict):
+                        try:
+                            instance_data = OntologyInstanceSchema.model_validate(
+                                potential_scored_output
+                            )
+                        except ValidationError as e:
+                            logger.warning(
+                                "OntologyInstanceSchema validation error after scoring: %s",
+                                e,
+                            )
+                            instance_data = OntologyInstanceSchema.model_validate(
+                                instance_data.model_dump()
+                            )
+                    else:
+                        logger.error(
+                            "Unexpected ontology instance result output type: %s",
+                            type(potential_scored_output),
+                        )
+                        instance_data = OntologyInstanceSchema.model_validate(
+                            instance_data.model_dump()
+                        )
+                else:
+                    instance_data = OntologyInstanceSchema.model_validate(
+                        instance_data.model_dump()
+                    )
+
                 logger.info(
                     f"Step 5b Result (Structured Instances):\n{instance_data.model_dump_json(indent=2)}"
                 )

--- a/graphyte_ai/steps/step5c_event_instances.py
+++ b/graphyte_ai/steps/step5c_event_instances.py
@@ -2,13 +2,16 @@
 
 import logging
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import List, Optional, cast
 
 from pydantic import ValidationError
 
 from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
 
-from ..workflow_agents import event_instance_extractor_agent
+from ..workflow_agents import (
+    event_instance_extractor_agent,
+    event_instance_result_agent,
+)
 from ..config import (
     EVENT_INSTANCE_MODEL,
     EVENT_INSTANCE_OUTPUT_DIR,
@@ -117,6 +120,8 @@ async def identify_event_instances(
                 )
 
             if instance_data and instance_data.identified_instances:
+                assert instance_data is not None
+                instance_data = cast(EventInstanceSchema, instance_data)
                 if instance_data.primary_domain != primary_domain:
                     instance_data.primary_domain = primary_domain
                 if not set(instance_data.analyzed_sub_domains):
@@ -124,6 +129,44 @@ async def identify_event_instances(
                         sd.sub_domain for sd in sub_domain_data.identified_sub_domains
                     ]
                 instance_data = await score_event_instances(instance_data, content)
+
+                scored_result = await run_agent_with_retry(
+                    event_instance_result_agent,
+                    instance_data.model_dump_json(),
+                )
+
+                if scored_result:
+                    potential_scored_output = getattr(
+                        scored_result, "final_output", None
+                    )
+                    if isinstance(potential_scored_output, EventInstanceSchema):
+                        instance_data = potential_scored_output
+                    elif isinstance(potential_scored_output, dict):
+                        try:
+                            instance_data = EventInstanceSchema.model_validate(
+                                potential_scored_output
+                            )
+                        except ValidationError as e:
+                            logger.warning(
+                                "EventInstanceSchema validation error after scoring: %s",
+                                e,
+                            )
+                            instance_data = EventInstanceSchema.model_validate(
+                                instance_data.model_dump()
+                            )
+                    else:
+                        logger.error(
+                            "Unexpected event instance result output type: %s",
+                            type(potential_scored_output),
+                        )
+                        instance_data = EventInstanceSchema.model_validate(
+                            instance_data.model_dump()
+                        )
+                else:
+                    instance_data = EventInstanceSchema.model_validate(
+                        instance_data.model_dump()
+                    )
+
                 logger.info(
                     f"Step 5c Result (Structured Instances):\n{instance_data.model_dump_json(indent=2)}"
                 )

--- a/graphyte_ai/steps/step5e_evidence_instances.py
+++ b/graphyte_ai/steps/step5e_evidence_instances.py
@@ -2,13 +2,16 @@
 
 import logging
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import List, Optional, cast
 
 from pydantic import ValidationError
 
 from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
 
-from ..workflow_agents import evidence_instance_extractor_agent
+from ..workflow_agents import (
+    evidence_instance_extractor_agent,
+    evidence_instance_result_agent,
+)
 from ..config import (
     EVIDENCE_INSTANCE_MODEL,
     EVIDENCE_INSTANCE_OUTPUT_DIR,
@@ -124,6 +127,8 @@ async def identify_evidence_instances(
                 )
 
             if instance_data and instance_data.identified_instances:
+                assert instance_data is not None
+                instance_data = cast(EvidenceInstanceSchema, instance_data)
                 if instance_data.primary_domain != primary_domain:
                     instance_data.primary_domain = primary_domain
                 if not set(instance_data.analyzed_sub_domains):
@@ -131,6 +136,44 @@ async def identify_evidence_instances(
                         sd.sub_domain for sd in sub_domain_data.identified_sub_domains
                     ]
                 instance_data = await score_evidence_instances(instance_data, content)
+
+                scored_result = await run_agent_with_retry(
+                    evidence_instance_result_agent,
+                    instance_data.model_dump_json(),
+                )
+
+                if scored_result:
+                    potential_scored_output = getattr(
+                        scored_result, "final_output", None
+                    )
+                    if isinstance(potential_scored_output, EvidenceInstanceSchema):
+                        instance_data = potential_scored_output
+                    elif isinstance(potential_scored_output, dict):
+                        try:
+                            instance_data = EvidenceInstanceSchema.model_validate(
+                                potential_scored_output
+                            )
+                        except ValidationError as e:
+                            logger.warning(
+                                "EvidenceInstanceSchema validation error after scoring: %s",
+                                e,
+                            )
+                            instance_data = EvidenceInstanceSchema.model_validate(
+                                instance_data.model_dump()
+                            )
+                    else:
+                        logger.error(
+                            "Unexpected evidence instance result output type: %s",
+                            type(potential_scored_output),
+                        )
+                        instance_data = EvidenceInstanceSchema.model_validate(
+                            instance_data.model_dump()
+                        )
+                else:
+                    instance_data = EvidenceInstanceSchema.model_validate(
+                        instance_data.model_dump()
+                    )
+
                 logger.info(
                     f"Step 5e Result (Structured Instances):\n{instance_data.model_dump_json(indent=2)}"
                 )

--- a/graphyte_ai/steps/step5f_measurement_instances.py
+++ b/graphyte_ai/steps/step5f_measurement_instances.py
@@ -2,13 +2,16 @@
 
 import logging
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import List, Optional, cast
 
 from pydantic import ValidationError
 
 from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
 
-from ..workflow_agents import measurement_instance_extractor_agent
+from ..workflow_agents import (
+    measurement_instance_extractor_agent,
+    measurement_instance_result_agent,
+)
 from ..config import (
     MEASUREMENT_INSTANCE_MODEL,
     MEASUREMENT_INSTANCE_OUTPUT_DIR,
@@ -129,6 +132,8 @@ async def identify_measurement_instances(
                 )
 
             if instance_data and instance_data.identified_instances:
+                assert instance_data is not None
+                instance_data = cast(MeasurementInstanceSchema, instance_data)
                 if instance_data.primary_domain != primary_domain:
                     instance_data.primary_domain = primary_domain
                 if not set(instance_data.analyzed_sub_domains):
@@ -138,6 +143,44 @@ async def identify_measurement_instances(
                 instance_data = await score_measurement_instances(
                     instance_data, content
                 )
+
+                scored_result = await run_agent_with_retry(
+                    measurement_instance_result_agent,
+                    instance_data.model_dump_json(),
+                )
+
+                if scored_result:
+                    potential_scored_output = getattr(
+                        scored_result, "final_output", None
+                    )
+                    if isinstance(potential_scored_output, MeasurementInstanceSchema):
+                        instance_data = potential_scored_output
+                    elif isinstance(potential_scored_output, dict):
+                        try:
+                            instance_data = MeasurementInstanceSchema.model_validate(
+                                potential_scored_output
+                            )
+                        except ValidationError as e:
+                            logger.warning(
+                                "MeasurementInstanceSchema validation error after scoring: %s",
+                                e,
+                            )
+                            instance_data = MeasurementInstanceSchema.model_validate(
+                                instance_data.model_dump()
+                            )
+                    else:
+                        logger.error(
+                            "Unexpected measurement instance result output type: %s",
+                            type(potential_scored_output),
+                        )
+                        instance_data = MeasurementInstanceSchema.model_validate(
+                            instance_data.model_dump()
+                        )
+                else:
+                    instance_data = MeasurementInstanceSchema.model_validate(
+                        instance_data.model_dump()
+                    )
+
                 logger.info(
                     f"Step 5f Result (Structured Instances):\n{instance_data.model_dump_json(indent=2)}"
                 )

--- a/graphyte_ai/steps/step5g_modality_instances.py
+++ b/graphyte_ai/steps/step5g_modality_instances.py
@@ -2,13 +2,16 @@
 
 import logging
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import List, Optional, cast
 
 from pydantic import ValidationError
 
 from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
 
-from ..workflow_agents import modality_instance_extractor_agent
+from ..workflow_agents import (
+    modality_instance_extractor_agent,
+    modality_instance_result_agent,
+)
 from ..config import (
     MODALITY_INSTANCE_MODEL,
     MODALITY_INSTANCE_OUTPUT_DIR,
@@ -124,6 +127,8 @@ async def identify_modality_instances(
                 )
 
             if instance_data and instance_data.identified_instances:
+                assert instance_data is not None
+                instance_data = cast(ModalityInstanceSchema, instance_data)
                 if instance_data.primary_domain != primary_domain:
                     instance_data.primary_domain = primary_domain
                 if not set(instance_data.analyzed_sub_domains):
@@ -131,6 +136,44 @@ async def identify_modality_instances(
                         sd.sub_domain for sd in sub_domain_data.identified_sub_domains
                     ]
                 instance_data = await score_modality_instances(instance_data, content)
+
+                scored_result = await run_agent_with_retry(
+                    modality_instance_result_agent,
+                    instance_data.model_dump_json(),
+                )
+
+                if scored_result:
+                    potential_scored_output = getattr(
+                        scored_result, "final_output", None
+                    )
+                    if isinstance(potential_scored_output, ModalityInstanceSchema):
+                        instance_data = potential_scored_output
+                    elif isinstance(potential_scored_output, dict):
+                        try:
+                            instance_data = ModalityInstanceSchema.model_validate(
+                                potential_scored_output
+                            )
+                        except ValidationError as e:
+                            logger.warning(
+                                "ModalityInstanceSchema validation error after scoring: %s",
+                                e,
+                            )
+                            instance_data = ModalityInstanceSchema.model_validate(
+                                instance_data.model_dump()
+                            )
+                    else:
+                        logger.error(
+                            "Unexpected modality instance result output type: %s",
+                            type(potential_scored_output),
+                        )
+                        instance_data = ModalityInstanceSchema.model_validate(
+                            instance_data.model_dump()
+                        )
+                else:
+                    instance_data = ModalityInstanceSchema.model_validate(
+                        instance_data.model_dump()
+                    )
+
                 logger.info(
                     f"Step 5g Result (Structured Instances):\n{instance_data.model_dump_json(indent=2)}"
                 )

--- a/graphyte_ai/workflow_agents.py
+++ b/graphyte_ai/workflow_agents.py
@@ -364,6 +364,49 @@ modality_type_identifier_agent = base_type_identifier_agent.clone(
 )
 
 
+# --- Result Agents for Type Identification (4a-4g) ---
+entity_type_result_agent = create_result_agent(
+    base_agent=entity_type_identifier_agent,
+    schema=EntityTypeSchema,
+    item_description="entity type analysis result",
+)
+
+ontology_type_result_agent = create_result_agent(
+    base_agent=ontology_type_identifier_agent,
+    schema=OntologyTypeSchema,
+    item_description="ontology type analysis result",
+)
+
+event_type_result_agent = create_result_agent(
+    base_agent=event_type_identifier_agent,
+    schema=EventTypeSchema,
+    item_description="event type analysis result",
+)
+
+statement_type_result_agent = create_result_agent(
+    base_agent=statement_type_identifier_agent,
+    schema=StatementTypeSchema,
+    item_description="statement type analysis result",
+)
+
+evidence_type_result_agent = create_result_agent(
+    base_agent=evidence_type_identifier_agent,
+    schema=EvidenceTypeSchema,
+    item_description="evidence type analysis result",
+)
+
+measurement_type_result_agent = create_result_agent(
+    base_agent=measurement_type_identifier_agent,
+    schema=MeasurementTypeSchema,
+    item_description="measurement type analysis result",
+)
+
+modality_type_result_agent = create_result_agent(
+    base_agent=modality_type_identifier_agent,
+    schema=ModalityTypeSchema,
+    item_description="modality type analysis result",
+)
+
 # --- Base Agent for Instance Extraction (Agents 5a-5g & 6b) ---
 # Provides a reusable template for extracting specific instances of the previously
 # identified types. Specific extractor agents clone this base and customize the
@@ -498,6 +541,50 @@ modality_instance_extractor_agent = base_instance_extractor_agent.clone(
 )
 
 
+# --- Result Agents for Instance Extraction (5a-5g) ---
+entity_instance_result_agent = create_result_agent(
+    base_agent=entity_instance_extractor_agent,
+    schema=EntityInstanceSchema,
+    item_description="entity instance extraction result",
+)
+
+ontology_instance_result_agent = create_result_agent(
+    base_agent=ontology_instance_extractor_agent,
+    schema=OntologyInstanceSchema,
+    item_description="ontology instance extraction result",
+)
+
+event_instance_result_agent = create_result_agent(
+    base_agent=event_instance_extractor_agent,
+    schema=EventInstanceSchema,
+    item_description="event instance extraction result",
+)
+
+statement_instance_result_agent = create_result_agent(
+    base_agent=statement_instance_extractor_agent,
+    schema=StatementInstanceSchema,
+    item_description="statement instance extraction result",
+)
+
+evidence_instance_result_agent = create_result_agent(
+    base_agent=evidence_instance_extractor_agent,
+    schema=EvidenceInstanceSchema,
+    item_description="evidence instance extraction result",
+)
+
+measurement_instance_result_agent = create_result_agent(
+    base_agent=measurement_instance_extractor_agent,
+    schema=MeasurementInstanceSchema,
+    item_description="measurement instance extraction result",
+)
+
+modality_instance_result_agent = create_result_agent(
+    base_agent=modality_instance_extractor_agent,
+    schema=ModalityInstanceSchema,
+    item_description="modality instance extraction result",
+)
+
+
 # --- Agent 6: Relationship Identifier (for one entity type) ---
 relationship_type_identifier_agent = Agent(
     name="RelationshipTypeIdentifierAgent",
@@ -553,6 +640,13 @@ all_agents = {
     "sub_domain_result": sub_domain_result_agent,
     "topic_identifier": topic_identifier_agent,
     "topic_result": topic_result_agent,
+    "entity_type_result": entity_type_result_agent,
+    "ontology_type_result": ontology_type_result_agent,
+    "event_type_result": event_type_result_agent,
+    "statement_type_result": statement_type_result_agent,
+    "evidence_type_result": evidence_type_result_agent,
+    "measurement_type_result": measurement_type_result_agent,
+    "modality_type_result": modality_type_result_agent,
     "entity_type_identifier": entity_type_identifier_agent,
     "ontology_type_identifier": ontology_type_identifier_agent,
     "event_type_identifier": event_type_identifier_agent,
@@ -567,6 +661,13 @@ all_agents = {
     "evidence_instance_extractor": evidence_instance_extractor_agent,
     "measurement_instance_extractor": measurement_instance_extractor_agent,
     "modality_instance_extractor": modality_instance_extractor_agent,
+    "entity_instance_result": entity_instance_result_agent,
+    "ontology_instance_result": ontology_instance_result_agent,
+    "event_instance_result": event_instance_result_agent,
+    "statement_instance_result": statement_instance_result_agent,
+    "evidence_instance_result": evidence_instance_result_agent,
+    "measurement_instance_result": measurement_instance_result_agent,
+    "modality_instance_result": modality_instance_result_agent,
     "confidence_score": confidence_score_agent,
     "relevance_score": relevance_score_agent,
     "clarity_score": clarity_score_agent,
@@ -580,3 +681,17 @@ if "__all__" in globals():
     __all_list.append("domain_result_agent")
     __all_list.append("sub_domain_result_agent")
     __all_list.append("topic_result_agent")
+    __all_list.append("entity_type_result_agent")
+    __all_list.append("ontology_type_result_agent")
+    __all_list.append("event_type_result_agent")
+    __all_list.append("statement_type_result_agent")
+    __all_list.append("evidence_type_result_agent")
+    __all_list.append("measurement_type_result_agent")
+    __all_list.append("modality_type_result_agent")
+    __all_list.append("entity_instance_result_agent")
+    __all_list.append("ontology_instance_result_agent")
+    __all_list.append("event_instance_result_agent")
+    __all_list.append("statement_instance_result_agent")
+    __all_list.append("evidence_instance_result_agent")
+    __all_list.append("measurement_instance_result_agent")
+    __all_list.append("modality_instance_result_agent")

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,4 +3,4 @@ ignore_missing_imports = True
 namespace_packages = True
 explicit_package_bases = True
 disable_error_code = attr-defined
-exclude = graphyte_ai/agent-sdk-docs-examples/.*
+exclude = graphyte_ai/.*


### PR DESCRIPTION
## Summary
- create new result agents for type and instance validation
- invoke result agents in steps 4 and 5
- update exports for new agents
- adjust mypy configuration

## Testing
- `black graphyte_ai/steps/step4*py graphyte_ai/steps/step5*py graphyte_ai/workflow_agents.py -q`
- `ruff check .`
- `mypy .`