### PR TITLE
Add scoring for relationship types

### DIFF
--- a/graphyte_ai/steps/step6a_relationship_types.py
+++ b/graphyte_ai/steps/step6a_relationship_types.py
@@ -22,7 +22,11 @@ from ..schemas import (
     TopicSchema,
     EntityTypeSchema,
 )
-from ..utils import direct_save_json_output, run_agent_with_retry
+from ..utils import (
+    direct_save_json_output,
+    run_agent_with_retry,
+    score_relationship_types,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -347,6 +351,8 @@ async def identify_relationship_types(
         entity_relationships_map=aggregated_relationship_results,  # List of successful results
         analysis_summary=f"Generated relationships in parallel focusing on {len(aggregated_relationship_results)} entity types (out of {len(entity_types_being_processed)} attempted).",
     )
+
+    relationship_data = await score_relationship_types(relationship_data, content)
 
     logger.info(
         f"Final Aggregated Relationships (Structured):\n{relationship_data.model_dump_json(indent=2)}"

--- a/graphyte_ai/workflow_agents.py
+++ b/graphyte_ai/workflow_agents.py
@@ -506,27 +506,12 @@ relationship_type_identifier_agent = Agent(
         "You will be given the *full text* and context, PLUS **one specific entity type** (identified in a previous step) to focus on (e.g., 'ORGANIZATION').\n"
         "Identify explicit or strongly implied relationships mentioned in the text where the **focus entity type** is involved as one of the participants.\n"
         "Examples of relationships: WORKS_FOR, LOCATED_IN, ACQUIRED, PARTNERED_WITH, COMPETES_WITH, FOUNDED_BY, MANUFACTURES, USES_TECHNOLOGY, etc.\n"
-        "For EACH identified relationship involving the focus entity type:\n"
-        "1. State the unique type of relationship found.\n"
-        "2. Call the confidence_score, relevance_score, and clarity_score tools to score the relationship before producing the final output.\n"
-        "Output ONLY the result using the provided SingleEntityTypeRelationshipSchema. Ensure the 'entity_type_focus' field matches the entity type you were asked to focus on. Every RelationshipDetail in the 'identified_relationships' list MUST include 'confidence_score', 'relevance_score', and 'clarity_score'. Do not add commentary outside the schema."
+        "For EACH identified relationship involving the focus entity type, state the unique type of relationship found.\n"
+        "Output ONLY the result using the provided SingleEntityTypeRelationshipSchema. Ensure the 'entity_type_focus' field matches the entity type you were asked to focus on."
     ),
     model=RELATIONSHIP_MODEL,
     output_type=SingleEntityTypeRelationshipSchema,
-    tools=[
-        confidence_score_agent.as_tool(
-            tool_name="confidence_score",
-            tool_description="Evaluate confidence between 0.0 and 1.0",
-        ),
-        relevance_score_agent.as_tool(
-            tool_name="relevance_score",
-            tool_description="Judge relevance between 0.0 and 1.0",
-        ),
-        clarity_score_agent.as_tool(
-            tool_name="clarity_score",
-            tool_description="Assess clarity between 0.0 and 1.0",
-        ),
-    ],
+    tools=[],
     handoffs=[],
 )
 


### PR DESCRIPTION
## Summary
- implement `score_relationship_types` to compute scores for each relationship type
- simplify `relationship_type_identifier_agent` and remove scoring tools
- apply relationship type scoring in step6a before saving results

## Testing
- `black .`
- `ruff check .`
- `mypy .`
