### PR TITLE
Add scoreless identifier schemas

### DIFF
--- a/graphyte_ai/schemas.py
+++ b/graphyte_ai/schemas.py
@@ -1129,3 +1129,717 @@ class ExtractedInstancesSchema(BaseModel):
     analysis_summary: Optional[str] = Field(
         None, description="Optional summary describing the aggregated instance data."
     )
+
+
+# --- Score-less Identifier Schemas ---
+
+
+class SubDomainIdentifierDetail(BaseModel):
+    """Represents a sub-domain without any scoring information."""
+
+    sub_domain: str = Field(
+        description="The specific sub-domain identified within the text."
+    )
+
+
+class SubDomainIdentifierSchema(BaseModel):
+    """Output of sub-domain identification without scores."""
+
+    primary_domain: str = Field(
+        description="The primary domain that was provided as input."
+    )
+    identified_sub_domains: List[SubDomainIdentifierDetail] = Field(
+        description=(
+            "A list of specific sub-domains identified within the text related to "
+            "the primary domain. Should not be empty if analysis was possible."
+        )
+    )
+    analysis_summary: Optional[str] = Field(
+        None, description="A brief summary or commentary on the sub-domain analysis."
+    )
+
+
+class TopicIdentifierDetail(BaseModel):
+    """Represents a single topic without scoring information."""
+
+    topic: str = Field(description="The specific topic identified within the text.")
+
+
+class SingleSubDomainTopicIdentifierSchema(BaseModel):
+    """Topics identified for a single sub-domain without scores."""
+
+    sub_domain: str = Field(description="The sub-domain being analyzed.")
+    identified_topics: List[TopicIdentifierDetail] = Field(
+        description="A list of specific topics identified within the text related to this sub-domain."
+    )
+
+
+class EntityTypeIdentifierDetail(BaseModel):
+    """Represents an entity type without scoring information."""
+
+    entity_type: str = Field(
+        description=(
+            "The classified type of the entity (e.g., PERSON, ORGANIZATION, LOCATION, "
+            "DATE, MONEY, PRODUCT, TECHNOLOGY, SCIENTIFIC_CONCEPT, ECONOMIC_INDICATOR)."
+        )
+    )
+
+
+class SingleSubDomainEntityTypeIdentifierSchema(BaseModel):
+    """Entity types identified for one sub-domain without scores."""
+
+    sub_domain: str = Field(description="The sub-domain these entity types relate to.")
+    topics: List[TopicIdentifierDetail] = Field(
+        description="Topics considered for this sub-domain."
+    )
+    identified_entities: List[EntityTypeIdentifierDetail] = Field(
+        description="Entity types extracted while analyzing the sub-domain and topics."
+    )
+    analysis_summary: Optional[str] = Field(
+        None,
+        description="Optional notes about the entity type analysis for this sub-domain.",
+    )
+
+
+class EntityTypeIdentifierSchema(BaseModel):
+    """Output of entity type identification without scores."""
+
+    primary_domain: str = Field(
+        description="The primary domain context provided for the analysis."
+    )
+    analyzed_sub_domains: List[str] = Field(
+        description="The list of sub-domains used as context during entity identification."
+    )
+    identified_entities: List[EntityTypeIdentifierDetail] = Field(
+        description="A list of specific entity types identified within the text, relevant to the provided context."
+    )
+    sub_domain_entity_map: List[SingleSubDomainEntityTypeIdentifierSchema] = Field(
+        default_factory=list,
+        description="Entity type results for each processed sub-domain.",
+    )
+    analysis_summary: Optional[str] = Field(
+        None,
+        description="A brief summary or commentary on the entity identification analysis.",
+    )
+
+
+class OntologyTypeIdentifierDetail(BaseModel):
+    """Represents an ontology type without scoring information."""
+
+    ontology_type: str = Field(
+        description=(
+            "The identified ontology type or concept (e.g., Schema.org:Person, FIBO:FinancialInstrument, GO:biological_process)."
+        )
+    )
+
+
+class SingleSubDomainOntologyTypeIdentifierSchema(BaseModel):
+    """Ontology types identified for one sub-domain without scores."""
+
+    sub_domain: str = Field(
+        description="The sub-domain these ontology types relate to."
+    )
+    topics: List[TopicIdentifierDetail] = Field(
+        description="Topics considered for this sub-domain."
+    )
+    identified_ontology_types: List[OntologyTypeIdentifierDetail] = Field(
+        description="Ontology types extracted while analyzing the sub-domain and topics."
+    )
+    analysis_summary: Optional[str] = Field(
+        None,
+        description="Optional notes about the ontology type analysis for this sub-domain.",
+    )
+
+
+class OntologyTypeIdentifierSchema(BaseModel):
+    """Output of ontology type identification without scores."""
+
+    primary_domain: str = Field(
+        description="The primary domain context provided for the analysis."
+    )
+    analyzed_sub_domains: List[str] = Field(
+        description="The list of sub-domains used as context during ontology identification."
+    )
+    identified_ontology_types: List[OntologyTypeIdentifierDetail] = Field(
+        description="A list of specific ontology types identified within the text, relevant to the provided context."
+    )
+    sub_domain_ontology_map: List[SingleSubDomainOntologyTypeIdentifierSchema] = Field(
+        default_factory=list,
+        description="Ontology type results for each processed sub-domain.",
+    )
+    analysis_summary: Optional[str] = Field(
+        None,
+        description="A brief summary or commentary on the ontology identification analysis.",
+    )
+
+
+class EventTypeIdentifierDetail(BaseModel):
+    """Represents an event type without scoring information."""
+
+    event_type: str = Field(
+        description=(
+            "The classified type of the event identified (e.g., Meeting, Acquisition, Conference, Product Launch, Election, Natural Disaster)."
+        )
+    )
+
+
+class SingleSubDomainEventTypeIdentifierSchema(BaseModel):
+    """Event types identified for one sub-domain without scores."""
+
+    sub_domain: str = Field(description="The sub-domain these event types relate to.")
+    topics: List[TopicIdentifierDetail] = Field(
+        description="Topics considered for this sub-domain."
+    )
+    identified_events: List[EventTypeIdentifierDetail] = Field(
+        description="Event types extracted while analyzing the sub-domain and topics."
+    )
+    analysis_summary: Optional[str] = Field(
+        None,
+        description="Optional notes about the event type analysis for this sub-domain.",
+    )
+
+
+class EventTypeIdentifierSchema(BaseModel):
+    """Output of event type identification without scores."""
+
+    primary_domain: str = Field(
+        description="The primary domain context provided for the analysis."
+    )
+    analyzed_sub_domains: List[str] = Field(
+        description="The list of sub-domains used as context during event identification."
+    )
+    identified_events: List[EventTypeIdentifierDetail] = Field(
+        description="A list of specific event types identified within the text, relevant to the provided context."
+    )
+    sub_domain_event_map: List[SingleSubDomainEventTypeIdentifierSchema] = Field(
+        default_factory=list,
+        description="Event type results for each processed sub-domain.",
+    )
+    analysis_summary: Optional[str] = Field(
+        None,
+        description="A brief summary or commentary on the event identification analysis.",
+    )
+
+
+class StatementTypeIdentifierDetail(BaseModel):
+    """Represents a statement type without scoring information."""
+
+    statement_type: str = Field(
+        description=(
+            "The classified type of the statement identified (e.g., Fact, Claim, Opinion, Question, Instruction, Hypothesis, Prediction)."
+        )
+    )
+
+
+class SingleSubDomainStatementTypeIdentifierSchema(BaseModel):
+    """Statement types identified for one sub-domain without scores."""
+
+    sub_domain: str = Field(
+        description="The sub-domain these statement types relate to."
+    )
+    topics: List[TopicIdentifierDetail] = Field(
+        description="Topics considered for this sub-domain."
+    )
+    identified_statements: List[StatementTypeIdentifierDetail] = Field(
+        description="Statement types extracted while analyzing the sub-domain and topics."
+    )
+    analysis_summary: Optional[str] = Field(
+        None,
+        description="Optional notes about the statement type analysis for this sub-domain.",
+    )
+
+
+class StatementTypeIdentifierSchema(BaseModel):
+    """Output of statement type identification without scores."""
+
+    primary_domain: str = Field(
+        description="The primary domain context provided for the analysis."
+    )
+    analyzed_sub_domains: List[str] = Field(
+        description="The list of sub-domains used as context during statement identification."
+    )
+    identified_statements: List[StatementTypeIdentifierDetail] = Field(
+        description="A list of specific statement types identified within the text, relevant to the provided context."
+    )
+    sub_domain_statement_map: List[SingleSubDomainStatementTypeIdentifierSchema] = (
+        Field(
+            default_factory=list,
+            description="Statement type results for each processed sub-domain.",
+        )
+    )
+    analysis_summary: Optional[str] = Field(
+        None,
+        description="A brief summary or commentary on the statement identification analysis.",
+    )
+
+
+class EvidenceTypeIdentifierDetail(BaseModel):
+    """Represents an evidence type without scoring information."""
+
+    evidence_type: str = Field(
+        description=(
+            "The classified type of evidence identified (e.g., Testimony, Document, Statistic, Anecdote, Expert Opinion, Observation, Example)."
+        )
+    )
+
+
+class SingleSubDomainEvidenceTypeIdentifierSchema(BaseModel):
+    """Evidence types identified for one sub-domain without scores."""
+
+    sub_domain: str = Field(
+        description="The sub-domain these evidence types relate to."
+    )
+    topics: List[TopicIdentifierDetail] = Field(
+        description="Topics considered for this sub-domain."
+    )
+    identified_evidence: List[EvidenceTypeIdentifierDetail] = Field(
+        description="Evidence types extracted while analyzing the sub-domain and topics."
+    )
+    analysis_summary: Optional[str] = Field(
+        None,
+        description="Optional notes about the evidence type analysis for this sub-domain.",
+    )
+
+
+class EvidenceTypeIdentifierSchema(BaseModel):
+    """Output of evidence type identification without scores."""
+
+    primary_domain: str = Field(
+        description="The primary domain context provided for the analysis."
+    )
+    analyzed_sub_domains: List[str] = Field(
+        description="The list of sub-domains used as context during evidence identification."
+    )
+    identified_evidence: List[EvidenceTypeIdentifierDetail] = Field(
+        description="A list of specific evidence types identified within the text, relevant to the provided context."
+    )
+    sub_domain_evidence_map: List[SingleSubDomainEvidenceTypeIdentifierSchema] = Field(
+        default_factory=list,
+        description="Evidence type results for each processed sub-domain.",
+    )
+    analysis_summary: Optional[str] = Field(
+        None,
+        description="A brief summary or commentary on the evidence identification analysis.",
+    )
+
+
+class MeasurementTypeIdentifierDetail(BaseModel):
+    """Represents a measurement type without scoring information."""
+
+    measurement_type: str = Field(
+        description=(
+            "The classified type of measurement identified (e.g., Financial Metric, Physical Quantity, Performance Indicator, Survey Result, Count, Ratio, Percentage)."
+        )
+    )
+
+
+class SingleSubDomainMeasurementTypeIdentifierSchema(BaseModel):
+    """Measurement types identified for one sub-domain without scores."""
+
+    sub_domain: str = Field(
+        description="The sub-domain these measurement types relate to."
+    )
+    topics: List[TopicIdentifierDetail] = Field(
+        description="Topics considered for this sub-domain."
+    )
+    identified_measurements: List[MeasurementTypeIdentifierDetail] = Field(
+        description="Measurement types extracted while analyzing the sub-domain and topics."
+    )
+    analysis_summary: Optional[str] = Field(
+        None,
+        description="Optional notes about the measurement type analysis for this sub-domain.",
+    )
+
+
+class MeasurementTypeIdentifierSchema(BaseModel):
+    """Output of measurement type identification without scores."""
+
+    primary_domain: str = Field(
+        description="The primary domain context provided for the analysis."
+    )
+    analyzed_sub_domains: List[str] = Field(
+        description="The list of sub-domains used as context during measurement identification."
+    )
+    identified_measurements: List[MeasurementTypeIdentifierDetail] = Field(
+        description="A list of specific measurement types identified within the text, relevant to the provided context."
+    )
+    sub_domain_measurement_map: List[SingleSubDomainMeasurementTypeIdentifierSchema] = (
+        Field(
+            default_factory=list,
+            description="Measurement type results for each processed sub-domain.",
+        )
+    )
+    analysis_summary: Optional[str] = Field(
+        None,
+        description="A brief summary or commentary on the measurement identification analysis.",
+    )
+
+
+class ModalityTypeIdentifierDetail(BaseModel):
+    """Represents a modality type without scoring information."""
+
+    modality_type: str = Field(
+        description=(
+            "The classified type of modality identified (e.g., Text, Image, Video, Audio, Table, Chart, Code Snippet, Mathematical Formula)."
+        )
+    )
+
+
+class SingleSubDomainModalityTypeIdentifierSchema(BaseModel):
+    """Modality types identified for one sub-domain without scores."""
+
+    sub_domain: str = Field(
+        description="The sub-domain these modality types relate to."
+    )
+    topics: List[TopicIdentifierDetail] = Field(
+        description="Topics considered for this sub-domain."
+    )
+    identified_modalities: List[ModalityTypeIdentifierDetail] = Field(
+        description="Modality types extracted while analyzing the sub-domain and topics."
+    )
+    analysis_summary: Optional[str] = Field(
+        None,
+        description="Optional notes about the modality type analysis for this sub-domain.",
+    )
+
+
+class ModalityTypeIdentifierSchema(BaseModel):
+    """Output of modality type identification without scores."""
+
+    primary_domain: str = Field(
+        description="The primary domain context provided for the analysis."
+    )
+    analyzed_sub_domains: List[str] = Field(
+        description="The list of sub-domains used as context during modality identification."
+    )
+    identified_modalities: List[ModalityTypeIdentifierDetail] = Field(
+        description="A list of specific modality types identified within the text, relevant to the provided context."
+    )
+    sub_domain_modality_map: List[SingleSubDomainModalityTypeIdentifierSchema] = Field(
+        default_factory=list,
+        description="Modality type results for each processed sub-domain.",
+    )
+    analysis_summary: Optional[str] = Field(
+        None,
+        description="A brief summary or commentary on the modality identification analysis.",
+    )
+
+
+class EntityInstanceIdentifierDetail(BaseModel):
+    """Represents a specific entity mention without scoring information."""
+
+    entity_type: str = Field(
+        description="The type of the entity as classified in previous steps."
+    )
+    text_span: str = Field(description="Exact text of the entity mention.")
+    start_char: Optional[int] = Field(
+        None,
+        description="Start character index of the mention in the full text (0-based).",
+    )
+    end_char: Optional[int] = Field(
+        None,
+        description="End character index of the mention in the full text (exclusive).",
+    )
+
+
+class EntityInstanceIdentifierSchema(BaseModel):
+    """Extracted entity instances without scores."""
+
+    primary_domain: str = Field(
+        description="The primary domain context for the extraction."
+    )
+    analyzed_sub_domains: List[str] = Field(
+        description="Sub-domains used as context during extraction."
+    )
+    analyzed_entity_types: List[str] = Field(
+        description="Entity types considered when extracting instances."
+    )
+    identified_instances: List[EntityInstanceIdentifierDetail] = Field(
+        description="List of extracted entity mentions with type and text span."
+    )
+    analysis_summary: Optional[str] = Field(
+        None, description="Optional summary of the entity instance extraction process."
+    )
+
+
+class OntologyInstanceIdentifierDetail(BaseModel):
+    """Represents a specific ontology concept mention without scoring."""
+
+    ontology_type: str = Field(
+        description="The ontology type or concept as classified in previous steps."
+    )
+    text_span: str = Field(description="Exact text of the ontology concept mention.")
+    start_char: Optional[int] = Field(
+        None,
+        description="Start character index of the mention in the full text (0-based).",
+    )
+    end_char: Optional[int] = Field(
+        None,
+        description="End character index of the mention in the full text (exclusive).",
+    )
+
+
+class OntologyInstanceIdentifierSchema(BaseModel):
+    """Extracted ontology instances without scores."""
+
+    primary_domain: str = Field(
+        description="The primary domain context for the extraction."
+    )
+    analyzed_sub_domains: List[str] = Field(
+        description="Sub-domains used as context during extraction."
+    )
+    analyzed_ontology_types: List[str] = Field(
+        description="Ontology types considered when extracting instances."
+    )
+    identified_instances: List[OntologyInstanceIdentifierDetail] = Field(
+        description="List of extracted ontology concept mentions with type and text span."
+    )
+    analysis_summary: Optional[str] = Field(
+        None,
+        description="Optional summary of the ontology instance extraction process.",
+    )
+
+
+class EventInstanceIdentifierDetail(BaseModel):
+    """Represents a specific event mention without scoring information."""
+
+    event_type: str = Field(
+        description="The event type as classified in previous steps."
+    )
+    text_span: str = Field(description="Exact text of the event mention.")
+    start_char: Optional[int] = Field(
+        None,
+        description="Start character index of the mention in the full text (0-based).",
+    )
+    end_char: Optional[int] = Field(
+        None,
+        description="End character index of the mention in the full text (exclusive).",
+    )
+
+
+class EventInstanceIdentifierSchema(BaseModel):
+    """Extracted event instances without scores."""
+
+    primary_domain: str = Field(
+        description="The primary domain context for the extraction."
+    )
+    analyzed_sub_domains: List[str] = Field(
+        description="Sub-domains used as context during extraction."
+    )
+    analyzed_event_types: List[str] = Field(
+        description="Event types considered when extracting instances."
+    )
+    identified_instances: List[EventInstanceIdentifierDetail] = Field(
+        description="List of extracted event mentions with type and text span."
+    )
+    analysis_summary: Optional[str] = Field(
+        None, description="Optional summary of the event instance extraction process."
+    )
+
+
+class StatementInstanceIdentifierDetail(BaseModel):
+    """Represents a specific statement mention without scoring information."""
+
+    statement_type: str = Field(
+        description="The statement type as classified in previous steps."
+    )
+    text_span: str = Field(
+        description="Exact text of the statement or snippet identified."
+    )
+    start_char: Optional[int] = Field(
+        None,
+        description="Start character index of the statement in the full text (0-based).",
+    )
+    end_char: Optional[int] = Field(
+        None,
+        description="End character index of the statement in the full text (exclusive).",
+    )
+
+
+class StatementInstanceIdentifierSchema(BaseModel):
+    """Extracted statement instances without scores."""
+
+    primary_domain: str = Field(
+        description="The primary domain context for the extraction."
+    )
+    analyzed_sub_domains: List[str] = Field(
+        description="Sub-domains used as context during extraction."
+    )
+    analyzed_statement_types: List[str] = Field(
+        description="Statement types considered when extracting instances."
+    )
+    identified_instances: List[StatementInstanceIdentifierDetail] = Field(
+        description="List of extracted statement mentions with type and text span."
+    )
+    analysis_summary: Optional[str] = Field(
+        None,
+        description="Optional summary of the statement instance extraction process.",
+    )
+
+
+class EvidenceInstanceIdentifierDetail(BaseModel):
+    """Represents a specific evidence mention without scoring information."""
+
+    evidence_type: str = Field(
+        description="The evidence type as classified in previous steps."
+    )
+    text_span: str = Field(description="Exact text of the evidence mention.")
+    start_char: Optional[int] = Field(
+        None,
+        description="Start character index of the mention in the full text (0-based).",
+    )
+    end_char: Optional[int] = Field(
+        None,
+        description="End character index of the mention in the full text (exclusive).",
+    )
+
+
+class EvidenceInstanceIdentifierSchema(BaseModel):
+    """Extracted evidence instances without scores."""
+
+    primary_domain: str = Field(
+        description="The primary domain context for the extraction."
+    )
+    analyzed_sub_domains: List[str] = Field(
+        description="Sub-domains used as context during extraction."
+    )
+    analyzed_evidence_types: List[str] = Field(
+        description="Evidence types considered when extracting instances."
+    )
+    identified_instances: List[EvidenceInstanceIdentifierDetail] = Field(
+        description="List of extracted evidence mentions with type and text span."
+    )
+    analysis_summary: Optional[str] = Field(
+        None,
+        description="Optional summary of the evidence instance extraction process.",
+    )
+
+
+class MeasurementInstanceIdentifierDetail(BaseModel):
+    """Represents a specific measurement mention without scoring information."""
+
+    measurement_type: str = Field(
+        description="The measurement type as classified in previous steps."
+    )
+    text_span: str = Field(description="Exact text of the measurement mention.")
+    start_char: Optional[int] = Field(
+        None,
+        description="Start character index of the mention in the full text (0-based).",
+    )
+    end_char: Optional[int] = Field(
+        None,
+        description="End character index of the mention in the full text (exclusive).",
+    )
+
+
+class MeasurementInstanceIdentifierSchema(BaseModel):
+    """Extracted measurement instances without scores."""
+
+    primary_domain: str = Field(
+        description="The primary domain context for the extraction."
+    )
+    analyzed_sub_domains: List[str] = Field(
+        description="Sub-domains used as context during extraction."
+    )
+    analyzed_measurement_types: List[str] = Field(
+        description="Measurement types considered when extracting instances."
+    )
+    identified_instances: List[MeasurementInstanceIdentifierDetail] = Field(
+        description="List of extracted measurement mentions with type and text span."
+    )
+    analysis_summary: Optional[str] = Field(
+        None,
+        description="Optional summary of the measurement instance extraction process.",
+    )
+
+
+class ModalityInstanceIdentifierDetail(BaseModel):
+    """Represents a specific modality mention without scoring information."""
+
+    modality_type: str = Field(
+        description="The modality type as classified in previous steps."
+    )
+    text_span: str = Field(
+        description="Exact text of the modality mention or reference."
+    )
+    start_char: Optional[int] = Field(
+        None,
+        description="Start character index of the mention in the full text (0-based).",
+    )
+    end_char: Optional[int] = Field(
+        None,
+        description="End character index of the mention in the full text (exclusive).",
+    )
+
+
+class ModalityInstanceIdentifierSchema(BaseModel):
+    """Extracted modality instances without scores."""
+
+    primary_domain: str = Field(
+        description="The primary domain context for the extraction."
+    )
+    analyzed_sub_domains: List[str] = Field(
+        description="Sub-domains used as context during extraction."
+    )
+    analyzed_modality_types: List[str] = Field(
+        description="Modality types considered when extracting instances."
+    )
+    identified_instances: List[ModalityInstanceIdentifierDetail] = Field(
+        description="List of extracted modality mentions with type and text span."
+    )
+    analysis_summary: Optional[str] = Field(
+        None,
+        description="Optional summary of the modality instance extraction process.",
+    )
+
+
+class RelationshipIdentifierDetail(BaseModel):
+    """Represents an identified relationship type without scores."""
+
+    relationship_type: str = Field(
+        description="The nature of the relationship identified (e.g., WORKS_FOR, LOCATED_IN, ACQUIRED, PARTNERS_WITH, COMPETES_WITH)."
+    )
+
+
+class SingleEntityTypeRelationshipIdentifierSchema(BaseModel):
+    """Relationships for a single entity type focus without scores."""
+
+    entity_type_focus: str = Field(
+        description="The specific entity type this analysis focused on (e.g., ORGANIZATION)."
+    )
+    identified_relationships: List[RelationshipIdentifierDetail] = Field(
+        description="A list of relationships involving the focus entity type identified within the text, relevant to the overall context."
+    )
+
+
+class RelationshipInstanceIdentifierDetail(BaseModel):
+    """Represents a specific relationship instance without scores."""
+
+    subject: str = Field(
+        description="The text span or identifier of the subject entity."
+    )
+    relationship_type: str = Field(
+        description="The type of relationship linking the subject and object."
+    )
+    object: str = Field(description="The text span or identifier of the object entity.")
+    snippet: Optional[str] = Field(
+        None, description="Optional text snippet supporting this relationship instance."
+    )
+
+
+class RelationshipInstanceIdentifierSchema(BaseModel):
+    """Extracted relationship instances without scores."""
+
+    primary_domain: str = Field(
+        description="The primary domain context for the extraction."
+    )
+    analyzed_sub_domains: List[str] = Field(
+        description="Sub-domains used as context during extraction."
+    )
+    identified_instances: List[RelationshipInstanceIdentifierDetail] = Field(
+        description="List of extracted relationship instances between specific entities."
+    )
+    analysis_summary: Optional[str] = Field(
+        None,
+        description="Optional summary of the relationship instance extraction process.",
+    )


### PR DESCRIPTION
## Summary
- add new identifier schemas without scoring fields for various steps

## Testing
- `black graphyte_ai/schemas.py`
- `ruff check .`
- `mypy .`
