### PR TITLE
Add scoreless base schemas

### DIFF
--- a/graphyte_ai/schemas.py
+++ b/graphyte_ai/schemas.py
@@ -1843,3 +1843,205 @@ class RelationshipInstanceIdentifierSchema(BaseModel):
         None,
         description="Optional summary of the relationship instance extraction process.",
     )
+
+
+# --- Score-less Base Schemas ---
+
+
+class SubDomainBaseDetail(SubDomainIdentifierDetail):
+    """Sub-domain detail without scoring information."""
+
+
+class SubDomainBaseSchema(SubDomainIdentifierSchema):
+    """Scoreless variant of :class:`SubDomainSchema`."""
+
+
+class SingleSubDomainEntityTypeBaseSchema(SingleSubDomainEntityTypeIdentifierSchema):
+    """Scoreless variant of :class:`SingleSubDomainEntityTypeSchema`."""
+
+
+class EntityTypeBaseDetail(EntityTypeIdentifierDetail):
+    """Entity type detail without scoring information."""
+
+
+class EntityTypeBaseSchema(EntityTypeIdentifierSchema):
+    """Scoreless variant of :class:`EntityTypeSchema`."""
+
+
+class SingleSubDomainOntologyTypeBaseSchema(
+    SingleSubDomainOntologyTypeIdentifierSchema
+):
+    """Scoreless variant of :class:`SingleSubDomainOntologyTypeSchema`."""
+
+
+class OntologyTypeBaseDetail(OntologyTypeIdentifierDetail):
+    """Ontology type detail without scoring information."""
+
+
+class OntologyTypeBaseSchema(OntologyTypeIdentifierSchema):
+    """Scoreless variant of :class:`OntologyTypeSchema`."""
+
+
+class SingleSubDomainEventTypeBaseSchema(SingleSubDomainEventTypeIdentifierSchema):
+    """Scoreless variant of :class:`SingleSubDomainEventTypeSchema`."""
+
+
+class EventTypeBaseDetail(EventTypeIdentifierDetail):
+    """Event type detail without scoring information."""
+
+
+class EventTypeBaseSchema(EventTypeIdentifierSchema):
+    """Scoreless variant of :class:`EventTypeSchema`."""
+
+
+class SingleSubDomainStatementTypeBaseSchema(
+    SingleSubDomainStatementTypeIdentifierSchema
+):
+    """Scoreless variant of :class:`SingleSubDomainStatementTypeSchema`."""
+
+
+class StatementTypeBaseDetail(StatementTypeIdentifierDetail):
+    """Statement type detail without scoring information."""
+
+
+class StatementTypeBaseSchema(StatementTypeIdentifierSchema):
+    """Scoreless variant of :class:`StatementTypeSchema`."""
+
+
+class SingleSubDomainEvidenceTypeBaseSchema(
+    SingleSubDomainEvidenceTypeIdentifierSchema
+):
+    """Scoreless variant of :class:`SingleSubDomainEvidenceTypeSchema`."""
+
+
+class EvidenceTypeBaseDetail(EvidenceTypeIdentifierDetail):
+    """Evidence type detail without scoring information."""
+
+
+class EvidenceTypeBaseSchema(EvidenceTypeIdentifierSchema):
+    """Scoreless variant of :class:`EvidenceTypeSchema`."""
+
+
+class SingleSubDomainMeasurementTypeBaseSchema(
+    SingleSubDomainMeasurementTypeIdentifierSchema
+):
+    """Scoreless variant of :class:`SingleSubDomainMeasurementTypeSchema`."""
+
+
+class MeasurementTypeBaseDetail(MeasurementTypeIdentifierDetail):
+    """Measurement type detail without scoring information."""
+
+
+class MeasurementTypeBaseSchema(MeasurementTypeIdentifierSchema):
+    """Scoreless variant of :class:`MeasurementTypeSchema`."""
+
+
+class SingleSubDomainModalityTypeBaseSchema(
+    SingleSubDomainModalityTypeIdentifierSchema
+):
+    """Scoreless variant of :class:`SingleSubDomainModalityTypeSchema`."""
+
+
+class ModalityTypeBaseDetail(ModalityTypeIdentifierDetail):
+    """Modality type detail without scoring information."""
+
+
+class ModalityTypeBaseSchema(ModalityTypeIdentifierSchema):
+    """Scoreless variant of :class:`ModalityTypeSchema`."""
+
+
+class EntityInstanceBaseDetail(EntityInstanceIdentifierDetail):
+    """Entity instance detail without scoring information."""
+
+
+class EntityInstanceBaseSchema(EntityInstanceIdentifierSchema):
+    """Scoreless variant of :class:`EntityInstanceSchema`."""
+
+
+class OntologyInstanceBaseDetail(OntologyInstanceIdentifierDetail):
+    """Ontology instance detail without scoring information."""
+
+
+class OntologyInstanceBaseSchema(OntologyInstanceIdentifierSchema):
+    """Scoreless variant of :class:`OntologyInstanceSchema`."""
+
+
+class EventInstanceBaseDetail(EventInstanceIdentifierDetail):
+    """Event instance detail without scoring information."""
+
+
+class EventInstanceBaseSchema(EventInstanceIdentifierSchema):
+    """Scoreless variant of :class:`EventInstanceSchema`."""
+
+
+class StatementInstanceBaseDetail(StatementInstanceIdentifierDetail):
+    """Statement instance detail without scoring information."""
+
+
+class StatementInstanceBaseSchema(StatementInstanceIdentifierSchema):
+    """Scoreless variant of :class:`StatementInstanceSchema`."""
+
+
+class EvidenceInstanceBaseDetail(EvidenceInstanceIdentifierDetail):
+    """Evidence instance detail without scoring information."""
+
+
+class EvidenceInstanceBaseSchema(EvidenceInstanceIdentifierSchema):
+    """Scoreless variant of :class:`EvidenceInstanceSchema`."""
+
+
+class MeasurementInstanceBaseDetail(MeasurementInstanceIdentifierDetail):
+    """Measurement instance detail without scoring information."""
+
+
+class MeasurementInstanceBaseSchema(MeasurementInstanceIdentifierSchema):
+    """Scoreless variant of :class:`MeasurementInstanceSchema`."""
+
+
+class ModalityInstanceBaseDetail(ModalityInstanceIdentifierDetail):
+    """Modality instance detail without scoring information."""
+
+
+class ModalityInstanceBaseSchema(ModalityInstanceIdentifierSchema):
+    """Scoreless variant of :class:`ModalityInstanceSchema`."""
+
+
+class RelationshipBaseDetail(RelationshipIdentifierDetail):
+    """Relationship type detail without scoring information."""
+
+
+class SingleEntityTypeRelationshipBaseSchema(
+    SingleEntityTypeRelationshipIdentifierSchema
+):
+    """Scoreless variant of :class:`SingleEntityTypeRelationshipSchema`."""
+
+
+class RelationshipBaseSchema(BaseModel):
+    """Scoreless variant of :class:`RelationshipSchema`."""
+
+    primary_domain: str = Field(
+        description="The overall primary domain provided as context."
+    )
+    analyzed_sub_domains: List[str] = Field(
+        description="The list of sub-domains used as context during relationship identification."
+    )
+    analyzed_entity_types: List[str] = Field(
+        description="The list of entity types that were analyzed in parallel for relationships."
+    )
+    entity_relationships_map: List[SingleEntityTypeRelationshipIdentifierSchema] = (
+        Field(
+            description="A list containing the relationship analysis results for each entity type focus."
+        )
+    )
+    analysis_summary: Optional[str] = Field(
+        None,
+        description="Optional summary of the relationship identification process across all analyzed entity types.",
+    )
+
+
+class RelationshipInstanceBaseDetail(RelationshipInstanceIdentifierDetail):
+    """Relationship instance detail without scoring information."""
+
+
+class RelationshipInstanceBaseSchema(RelationshipInstanceIdentifierSchema):
+    """Scoreless variant of :class:`RelationshipInstanceSchema`."""


### PR DESCRIPTION
## Summary
- add new `Base` variants for scoreless results in `schemas.py`

## Testing
- `ruff check graphyte_ai/schemas.py`
- `mypy .`