### PR TITLE
Add result agents for scored workflow data

### DIFF
--- a/graphyte_ai/steps/step4c_event_types.py
+++ b/graphyte_ai/steps/step4c_event_types.py
@@ -8,7 +8,10 @@ from pydantic import ValidationError
 
 from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
 
-from ..workflow_agents import event_type_identifier_agent  # Import the new agent
+from ..workflow_agents import (
+    event_type_identifier_agent,  # Import the new agent
+    event_type_result_agent,
+)
 from ..config import (
     EVENT_TYPE_MODEL,
     EVENT_TYPE_OUTPUT_DIR,
@@ -151,6 +154,41 @@ async def identify_event_types(
                     )
 
                 event_data = await score_event_types(event_data, content)
+
+                scored_result = await run_agent_with_retry(
+                    event_type_result_agent,
+                    event_data.model_dump_json(),
+                )
+
+                if scored_result:
+                    potential_scored_output = getattr(
+                        scored_result, "final_output", None
+                    )
+                    if isinstance(potential_scored_output, EventTypeSchema):
+                        event_data = potential_scored_output
+                    elif isinstance(potential_scored_output, dict):
+                        try:
+                            event_data = EventTypeSchema.model_validate(
+                                potential_scored_output
+                            )
+                        except ValidationError as e:
+                            logger.warning(
+                                "EventTypeSchema validation error after scoring: %s",
+                                e,
+                            )
+                            event_data = EventTypeSchema.model_validate(
+                                event_data.model_dump()
+                            )
+                    else:
+                        logger.error(
+                            "Unexpected event type result output type: %s",
+                            type(potential_scored_output),
+                        )
+                        event_data = EventTypeSchema.model_validate(
+                            event_data.model_dump()
+                        )
+                else:
+                    event_data = EventTypeSchema.model_validate(event_data.model_dump())
 
                 # Log and print results
                 event_log_items = [

--- a/graphyte_ai/steps/step4e_evidence_types.py
+++ b/graphyte_ai/steps/step4e_evidence_types.py
@@ -13,7 +13,10 @@ except ImportError:
     print("Error: 'agents' SDK library not found or incomplete for step 4e.")
     raise
 
-from ..workflow_agents import evidence_type_identifier_agent  # Import the new agent
+from ..workflow_agents import (
+    evidence_type_identifier_agent,  # Import the new agent
+    evidence_type_result_agent,
+)
 from ..config import (
     EVIDENCE_TYPE_MODEL,
     EVIDENCE_TYPE_OUTPUT_DIR,
@@ -160,6 +163,43 @@ async def identify_evidence_types(
                     )
 
                 evidence_data = await score_evidence_types(evidence_data, content)
+
+                scored_result = await run_agent_with_retry(
+                    evidence_type_result_agent,
+                    evidence_data.model_dump_json(),
+                )
+
+                if scored_result:
+                    potential_scored_output = getattr(
+                        scored_result, "final_output", None
+                    )
+                    if isinstance(potential_scored_output, EvidenceTypeSchema):
+                        evidence_data = potential_scored_output
+                    elif isinstance(potential_scored_output, dict):
+                        try:
+                            evidence_data = EvidenceTypeSchema.model_validate(
+                                potential_scored_output
+                            )
+                        except ValidationError as e:
+                            logger.warning(
+                                "EvidenceTypeSchema validation error after scoring: %s",
+                                e,
+                            )
+                            evidence_data = EvidenceTypeSchema.model_validate(
+                                evidence_data.model_dump()
+                            )
+                    else:
+                        logger.error(
+                            "Unexpected evidence type result output type: %s",
+                            type(potential_scored_output),
+                        )
+                        evidence_data = EvidenceTypeSchema.model_validate(
+                            evidence_data.model_dump()
+                        )
+                else:
+                    evidence_data = EvidenceTypeSchema.model_validate(
+                        evidence_data.model_dump()
+                    )
 
                 # Log and print results
                 evidence_log_items = [

--- a/graphyte_ai/steps/step4g_modality_types.py
+++ b/graphyte_ai/steps/step4g_modality_types.py
@@ -13,7 +13,10 @@ except ImportError:
     print("Error: 'agents' SDK library not found or incomplete for step 4g.")
     raise
 
-from ..workflow_agents import modality_type_identifier_agent  # Import the new agent
+from ..workflow_agents import (
+    modality_type_identifier_agent,  # Import the new agent
+    modality_type_result_agent,
+)
 from ..config import (
     MODALITY_TYPE_MODEL,
     MODALITY_TYPE_OUTPUT_DIR,
@@ -160,6 +163,43 @@ async def identify_modality_types(
                     )
 
                 modality_data = await score_modality_types(modality_data, content)
+
+                scored_result = await run_agent_with_retry(
+                    modality_type_result_agent,
+                    modality_data.model_dump_json(),
+                )
+
+                if scored_result:
+                    potential_scored_output = getattr(
+                        scored_result, "final_output", None
+                    )
+                    if isinstance(potential_scored_output, ModalityTypeSchema):
+                        modality_data = potential_scored_output
+                    elif isinstance(potential_scored_output, dict):
+                        try:
+                            modality_data = ModalityTypeSchema.model_validate(
+                                potential_scored_output
+                            )
+                        except ValidationError as e:
+                            logger.warning(
+                                "ModalityTypeSchema validation error after scoring: %s",
+                                e,
+                            )
+                            modality_data = ModalityTypeSchema.model_validate(
+                                modality_data.model_dump()
+                            )
+                    else:
+                        logger.error(
+                            "Unexpected modality type result output type: %s",
+                            type(potential_scored_output),
+                        )
+                        modality_data = ModalityTypeSchema.model_validate(
+                            modality_data.model_dump()
+                        )
+                else:
+                    modality_data = ModalityTypeSchema.model_validate(
+                        modality_data.model_dump()
+                    )
 
                 # Log and print results
                 modality_log_items = [

--- a/graphyte_ai/steps/step5a_entity_instances.py
+++ b/graphyte_ai/steps/step5a_entity_instances.py
@@ -8,7 +8,10 @@ from pydantic import ValidationError
 
 from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
 
-from ..workflow_agents import entity_instance_extractor_agent
+from ..workflow_agents import (
+    entity_instance_extractor_agent,
+    entity_instance_result_agent,
+)
 from ..config import (
     ENTITY_INSTANCE_MODEL,
     ENTITY_INSTANCE_OUTPUT_DIR,
@@ -132,6 +135,43 @@ async def identify_entity_instances(
                         sd.sub_domain for sd in sub_domain_data.identified_sub_domains
                     ]
                 instance_data = await score_entity_instances(instance_data, content)
+
+                scored_result = await run_agent_with_retry(
+                    entity_instance_result_agent,
+                    instance_data.model_dump_json(),
+                )
+
+                if scored_result:
+                    potential_scored_output = getattr(
+                        scored_result, "final_output", None
+                    )
+                    if isinstance(potential_scored_output, EntityInstanceSchema):
+                        instance_data = potential_scored_output
+                    elif isinstance(potential_scored_output, dict):
+                        try:
+                            instance_data = EntityInstanceSchema.model_validate(
+                                potential_scored_output
+                            )
+                        except ValidationError as e:
+                            logger.warning(
+                                "EntityInstanceSchema validation error after scoring: %s",
+                                e,
+                            )
+                            instance_data = EntityInstanceSchema.model_validate(
+                                instance_data.model_dump()
+                            )
+                    else:
+                        logger.error(
+                            "Unexpected entity instance result output type: %s",
+                            type(potential_scored_output),
+                        )
+                        instance_data = EntityInstanceSchema.model_validate(
+                            instance_data.model_dump()
+                        )
+                else:
+                    instance_data = EntityInstanceSchema.model_validate(
+                        instance_data.model_dump()
+                    )
                 logger.info(
                     f"Step 5a Result (Structured Instances):\n{instance_data.model_dump_json(indent=2)}"
                 )

--- a/graphyte_ai/steps/step5c_event_instances.py
+++ b/graphyte_ai/steps/step5c_event_instances.py
@@ -8,7 +8,10 @@ from pydantic import ValidationError
 
 from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
 
-from ..workflow_agents import event_instance_extractor_agent
+from ..workflow_agents import (
+    event_instance_extractor_agent,
+    event_instance_result_agent,
+)
 from ..config import (
     EVENT_INSTANCE_MODEL,
     EVENT_INSTANCE_OUTPUT_DIR,
@@ -124,6 +127,43 @@ async def identify_event_instances(
                         sd.sub_domain for sd in sub_domain_data.identified_sub_domains
                     ]
                 instance_data = await score_event_instances(instance_data, content)
+
+                scored_result = await run_agent_with_retry(
+                    event_instance_result_agent,
+                    instance_data.model_dump_json(),
+                )
+
+                if scored_result:
+                    potential_scored_output = getattr(
+                        scored_result, "final_output", None
+                    )
+                    if isinstance(potential_scored_output, EventInstanceSchema):
+                        instance_data = potential_scored_output
+                    elif isinstance(potential_scored_output, dict):
+                        try:
+                            instance_data = EventInstanceSchema.model_validate(
+                                potential_scored_output
+                            )
+                        except ValidationError as e:
+                            logger.warning(
+                                "EventInstanceSchema validation error after scoring: %s",
+                                e,
+                            )
+                            instance_data = EventInstanceSchema.model_validate(
+                                instance_data.model_dump()
+                            )
+                    else:
+                        logger.error(
+                            "Unexpected event instance result output type: %s",
+                            type(potential_scored_output),
+                        )
+                        instance_data = EventInstanceSchema.model_validate(
+                            instance_data.model_dump()
+                        )
+                else:
+                    instance_data = EventInstanceSchema.model_validate(
+                        instance_data.model_dump()
+                    )
                 logger.info(
                     f"Step 5c Result (Structured Instances):\n{instance_data.model_dump_json(indent=2)}"
                 )

--- a/graphyte_ai/steps/step5d_statement_instances.py
+++ b/graphyte_ai/steps/step5d_statement_instances.py
@@ -8,7 +8,10 @@ from pydantic import ValidationError
 
 from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
 
-from ..workflow_agents import statement_instance_extractor_agent
+from ..workflow_agents import (
+    statement_instance_extractor_agent,
+    statement_instance_result_agent,
+)
 from ..config import (
     STATEMENT_INSTANCE_MODEL,
     STATEMENT_INSTANCE_OUTPUT_DIR,
@@ -136,6 +139,43 @@ async def identify_statement_instances(
                         sd.sub_domain for sd in sub_domain_data.identified_sub_domains
                     ]
                 instance_data = await score_statement_instances(instance_data, content)
+
+                scored_result = await run_agent_with_retry(
+                    statement_instance_result_agent,
+                    instance_data.model_dump_json(),
+                )
+
+                if scored_result:
+                    potential_scored_output = getattr(
+                        scored_result, "final_output", None
+                    )
+                    if isinstance(potential_scored_output, StatementInstanceSchema):
+                        instance_data = potential_scored_output
+                    elif isinstance(potential_scored_output, dict):
+                        try:
+                            instance_data = StatementInstanceSchema.model_validate(
+                                potential_scored_output
+                            )
+                        except ValidationError as e:
+                            logger.warning(
+                                "StatementInstanceSchema validation error after scoring: %s",
+                                e,
+                            )
+                            instance_data = StatementInstanceSchema.model_validate(
+                                instance_data.model_dump()
+                            )
+                    else:
+                        logger.error(
+                            "Unexpected statement instance result output type: %s",
+                            type(potential_scored_output),
+                        )
+                        instance_data = StatementInstanceSchema.model_validate(
+                            instance_data.model_dump()
+                        )
+                else:
+                    instance_data = StatementInstanceSchema.model_validate(
+                        instance_data.model_dump()
+                    )
                 logger.info(
                     f"Step 5d Result (Structured Instances):\n{instance_data.model_dump_json(indent=2)}"
                 )

--- a/graphyte_ai/steps/step5e_evidence_instances.py
+++ b/graphyte_ai/steps/step5e_evidence_instances.py
@@ -8,7 +8,10 @@ from pydantic import ValidationError
 
 from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
 
-from ..workflow_agents import evidence_instance_extractor_agent
+from ..workflow_agents import (
+    evidence_instance_extractor_agent,
+    evidence_instance_result_agent,
+)
 from ..config import (
     EVIDENCE_INSTANCE_MODEL,
     EVIDENCE_INSTANCE_OUTPUT_DIR,
@@ -131,6 +134,43 @@ async def identify_evidence_instances(
                         sd.sub_domain for sd in sub_domain_data.identified_sub_domains
                     ]
                 instance_data = await score_evidence_instances(instance_data, content)
+
+                scored_result = await run_agent_with_retry(
+                    evidence_instance_result_agent,
+                    instance_data.model_dump_json(),
+                )
+
+                if scored_result:
+                    potential_scored_output = getattr(
+                        scored_result, "final_output", None
+                    )
+                    if isinstance(potential_scored_output, EvidenceInstanceSchema):
+                        instance_data = potential_scored_output
+                    elif isinstance(potential_scored_output, dict):
+                        try:
+                            instance_data = EvidenceInstanceSchema.model_validate(
+                                potential_scored_output
+                            )
+                        except ValidationError as e:
+                            logger.warning(
+                                "EvidenceInstanceSchema validation error after scoring: %s",
+                                e,
+                            )
+                            instance_data = EvidenceInstanceSchema.model_validate(
+                                instance_data.model_dump()
+                            )
+                    else:
+                        logger.error(
+                            "Unexpected evidence instance result output type: %s",
+                            type(potential_scored_output),
+                        )
+                        instance_data = EvidenceInstanceSchema.model_validate(
+                            instance_data.model_dump()
+                        )
+                else:
+                    instance_data = EvidenceInstanceSchema.model_validate(
+                        instance_data.model_dump()
+                    )
                 logger.info(
                     f"Step 5e Result (Structured Instances):\n{instance_data.model_dump_json(indent=2)}"
                 )

--- a/graphyte_ai/steps/step5g_modality_instances.py
+++ b/graphyte_ai/steps/step5g_modality_instances.py
@@ -8,7 +8,10 @@ from pydantic import ValidationError
 
 from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
 
-from ..workflow_agents import modality_instance_extractor_agent
+from ..workflow_agents import (
+    modality_instance_extractor_agent,
+    modality_instance_result_agent,
+)
 from ..config import (
     MODALITY_INSTANCE_MODEL,
     MODALITY_INSTANCE_OUTPUT_DIR,
@@ -131,6 +134,43 @@ async def identify_modality_instances(
                         sd.sub_domain for sd in sub_domain_data.identified_sub_domains
                     ]
                 instance_data = await score_modality_instances(instance_data, content)
+
+                scored_result = await run_agent_with_retry(
+                    modality_instance_result_agent,
+                    instance_data.model_dump_json(),
+                )
+
+                if scored_result:
+                    potential_scored_output = getattr(
+                        scored_result, "final_output", None
+                    )
+                    if isinstance(potential_scored_output, ModalityInstanceSchema):
+                        instance_data = potential_scored_output
+                    elif isinstance(potential_scored_output, dict):
+                        try:
+                            instance_data = ModalityInstanceSchema.model_validate(
+                                potential_scored_output
+                            )
+                        except ValidationError as e:
+                            logger.warning(
+                                "ModalityInstanceSchema validation error after scoring: %s",
+                                e,
+                            )
+                            instance_data = ModalityInstanceSchema.model_validate(
+                                instance_data.model_dump()
+                            )
+                    else:
+                        logger.error(
+                            "Unexpected modality instance result output type: %s",
+                            type(potential_scored_output),
+                        )
+                        instance_data = ModalityInstanceSchema.model_validate(
+                            instance_data.model_dump()
+                        )
+                else:
+                    instance_data = ModalityInstanceSchema.model_validate(
+                        instance_data.model_dump()
+                    )
                 logger.info(
                     f"Step 5g Result (Structured Instances):\n{instance_data.model_dump_json(indent=2)}"
                 )

--- a/graphyte_ai/steps/step6b_relationship_instances.py
+++ b/graphyte_ai/steps/step6b_relationship_instances.py
@@ -8,7 +8,10 @@ from pydantic import ValidationError
 
 from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
 
-from ..workflow_agents import relationship_extractor_agent
+from ..workflow_agents import (
+    relationship_extractor_agent,
+    relationship_instance_result_agent,
+)
 from ..config import (
     RELATIONSHIP_INSTANCE_MODEL,
     RELATIONSHIP_INSTANCE_OUTPUT_DIR,
@@ -117,6 +120,39 @@ async def identify_relationship_instances(
             if final.primary_domain != primary_domain:
                 final.primary_domain = primary_domain
             final = await score_relationship_instances(final, content)
+
+            scored_result = await run_agent_with_retry(
+                relationship_instance_result_agent,
+                final.model_dump_json(),
+            )
+
+            if scored_result:
+                potential_scored_output = getattr(scored_result, "final_output", None)
+                if isinstance(potential_scored_output, RelationshipInstanceSchema):
+                    final = potential_scored_output
+                elif isinstance(potential_scored_output, dict):
+                    try:
+                        final = RelationshipInstanceSchema.model_validate(
+                            potential_scored_output
+                        )
+                    except ValidationError as e:
+                        logger.warning(
+                            "RelationshipInstanceSchema validation error after scoring: %s",
+                            e,
+                        )
+                        final = RelationshipInstanceSchema.model_validate(
+                            final.model_dump()
+                        )
+                else:
+                    logger.error(
+                        "Unexpected relationship instance result output type: %s",
+                        type(potential_scored_output),
+                    )
+                    final = RelationshipInstanceSchema.model_validate(
+                        final.model_dump()
+                    )
+            else:
+                final = RelationshipInstanceSchema.model_validate(final.model_dump())
             logger.info("Step 6b result:\n%s", final.model_dump_json(indent=2))
             print("\n--- Relationship Instances Extracted (Structured Output) ---")
             print(final.model_dump_json(indent=2))

--- a/graphyte_ai/workflow_agents.py
+++ b/graphyte_ai/workflow_agents.py
@@ -23,15 +23,31 @@ from .schemas import (
     EvidenceTypeBaseSchema,
     MeasurementTypeBaseSchema,
     ModalityTypeBaseSchema,
+    EntityTypeSchema,
+    OntologyTypeSchema,
+    EventTypeSchema,
+    StatementTypeSchema,
+    EvidenceTypeSchema,
+    MeasurementTypeSchema,
+    ModalityTypeSchema,
     EntityInstanceBaseSchema,
+    EntityInstanceSchema,
     StatementInstanceBaseSchema,
+    StatementInstanceSchema,
     EvidenceInstanceBaseSchema,
+    EvidenceInstanceSchema,
     MeasurementInstanceBaseSchema,
+    MeasurementInstanceSchema,
     ModalityInstanceBaseSchema,
+    ModalityInstanceSchema,
     SingleEntityTypeRelationshipBaseSchema,
+    RelationshipSchema,
     RelationshipInstanceBaseSchema,
+    RelationshipInstanceSchema,
     OntologyInstanceBaseSchema,
+    OntologyInstanceSchema,
     EventInstanceBaseSchema,
+    EventInstanceSchema,
     ConfidenceScoreSchema,
     RelevanceScoreSchema,
     ClarityScoreSchema,
@@ -280,6 +296,12 @@ entity_type_identifier_agent = base_type_identifier_agent.clone(
     output_type=EntityTypeBaseSchema,
 )
 
+entity_type_result_agent = create_result_agent(
+    base_agent=entity_type_identifier_agent,
+    schema=EntityTypeSchema,
+    item_description="entity type list",
+)
+
 # --- Agent 4b: Ontology Type Identifier ---
 ontology_type_identifier_agent = base_type_identifier_agent.clone(
     name="OntologyTypeIdentifierAgent",
@@ -292,6 +314,12 @@ ontology_type_identifier_agent = base_type_identifier_agent.clone(
     ),
     model=ONTOLOGY_TYPE_MODEL,
     output_type=OntologyTypeBaseSchema,
+)
+
+ontology_type_result_agent = create_result_agent(
+    base_agent=ontology_type_identifier_agent,
+    schema=OntologyTypeSchema,
+    item_description="ontology type list",
 )
 
 # --- Agent 4c: Event Type Identifier ---
@@ -308,6 +336,12 @@ event_type_identifier_agent = base_type_identifier_agent.clone(
     output_type=EventTypeBaseSchema,
 )
 
+event_type_result_agent = create_result_agent(
+    base_agent=event_type_identifier_agent,
+    schema=EventTypeSchema,
+    item_description="event type list",
+)
+
 # --- Agent 4d: Statement Type Identifier ---
 statement_type_identifier_agent = base_type_identifier_agent.clone(
     name="StatementTypeIdentifierAgent",
@@ -320,6 +354,12 @@ statement_type_identifier_agent = base_type_identifier_agent.clone(
     ),
     model=STATEMENT_TYPE_MODEL,
     output_type=StatementTypeBaseSchema,
+)
+
+statement_type_result_agent = create_result_agent(
+    base_agent=statement_type_identifier_agent,
+    schema=StatementTypeSchema,
+    item_description="statement type list",
 )
 
 # --- Agent 4e: Evidence Type Identifier ---
@@ -336,6 +376,12 @@ evidence_type_identifier_agent = base_type_identifier_agent.clone(
     output_type=EvidenceTypeBaseSchema,
 )
 
+evidence_type_result_agent = create_result_agent(
+    base_agent=evidence_type_identifier_agent,
+    schema=EvidenceTypeSchema,
+    item_description="evidence type list",
+)
+
 # --- Agent 4f: Measurement Type Identifier ---
 measurement_type_identifier_agent = base_type_identifier_agent.clone(
     name="MeasurementTypeIdentifierAgent",
@@ -350,6 +396,12 @@ measurement_type_identifier_agent = base_type_identifier_agent.clone(
     output_type=MeasurementTypeBaseSchema,
 )
 
+measurement_type_result_agent = create_result_agent(
+    base_agent=measurement_type_identifier_agent,
+    schema=MeasurementTypeSchema,
+    item_description="measurement type list",
+)
+
 # --- Agent 4g: Modality Type Identifier ---
 modality_type_identifier_agent = base_type_identifier_agent.clone(
     name="ModalityTypeIdentifierAgent",
@@ -362,6 +414,12 @@ modality_type_identifier_agent = base_type_identifier_agent.clone(
     ),
     model=MODALITY_TYPE_MODEL,
     output_type=ModalityTypeBaseSchema,
+)
+
+modality_type_result_agent = create_result_agent(
+    base_agent=modality_type_identifier_agent,
+    schema=ModalityTypeSchema,
+    item_description="modality type list",
 )
 
 
@@ -402,6 +460,12 @@ entity_instance_extractor_agent = base_instance_extractor_agent.clone(
     output_type=EntityInstanceBaseSchema,
 )
 
+entity_instance_result_agent = create_result_agent(
+    base_agent=entity_instance_extractor_agent,
+    schema=EntityInstanceSchema,
+    item_description="entity instance list",
+)
+
 
 # --- Agent 5b: Ontology Instance Extractor ---
 # Clone of base_instance_extractor_agent specialized for ontology concepts.
@@ -416,6 +480,12 @@ ontology_instance_extractor_agent = base_instance_extractor_agent.clone(
     ),
     model=ONTOLOGY_INSTANCE_MODEL,
     output_type=OntologyInstanceBaseSchema,
+)
+
+ontology_instance_result_agent = create_result_agent(
+    base_agent=ontology_instance_extractor_agent,
+    schema=OntologyInstanceSchema,
+    item_description="ontology instance list",
 )
 
 
@@ -434,6 +504,12 @@ event_instance_extractor_agent = base_instance_extractor_agent.clone(
     output_type=EventInstanceBaseSchema,
 )
 
+event_instance_result_agent = create_result_agent(
+    base_agent=event_instance_extractor_agent,
+    schema=EventInstanceSchema,
+    item_description="event instance list",
+)
+
 
 # --- Agent 5d: Statement Instance Extractor ---
 # Clone of base_instance_extractor_agent specialized for statement snippets.
@@ -448,6 +524,12 @@ statement_instance_extractor_agent = base_instance_extractor_agent.clone(
     ),
     model=STATEMENT_INSTANCE_MODEL,
     output_type=StatementInstanceBaseSchema,
+)
+
+statement_instance_result_agent = create_result_agent(
+    base_agent=statement_instance_extractor_agent,
+    schema=StatementInstanceSchema,
+    item_description="statement instance list",
 )
 
 
@@ -466,6 +548,12 @@ evidence_instance_extractor_agent = base_instance_extractor_agent.clone(
     output_type=EvidenceInstanceBaseSchema,
 )
 
+evidence_instance_result_agent = create_result_agent(
+    base_agent=evidence_instance_extractor_agent,
+    schema=EvidenceInstanceSchema,
+    item_description="evidence instance list",
+)
+
 
 # --- Agent 5f: Measurement Instance Extractor ---
 # Clone of base_instance_extractor_agent specialized for measurement mentions.
@@ -482,6 +570,12 @@ measurement_instance_extractor_agent = base_instance_extractor_agent.clone(
     output_type=MeasurementInstanceBaseSchema,
 )
 
+measurement_instance_result_agent = create_result_agent(
+    base_agent=measurement_instance_extractor_agent,
+    schema=MeasurementInstanceSchema,
+    item_description="measurement instance list",
+)
+
 
 # --- Agent 5g: Modality Instance Extractor ---
 # Clone of base_instance_extractor_agent specialized for modality references.
@@ -496,6 +590,12 @@ modality_instance_extractor_agent = base_instance_extractor_agent.clone(
     ),
     model=MODALITY_INSTANCE_MODEL,
     output_type=ModalityInstanceBaseSchema,
+)
+
+modality_instance_result_agent = create_result_agent(
+    base_agent=modality_instance_extractor_agent,
+    schema=ModalityInstanceSchema,
+    item_description="modality instance list",
 )
 
 
@@ -516,6 +616,12 @@ relationship_type_identifier_agent = Agent(
     handoffs=[],
 )
 
+relationship_result_agent = create_result_agent(
+    base_agent=relationship_type_identifier_agent,
+    schema=RelationshipSchema,
+    item_description="relationship analysis result",
+)
+
 # --- Agent 6b: Relationship Instance Extractor ---
 # Clone of base_instance_extractor_agent specialized for relationship instances.
 relationship_extractor_agent = base_instance_extractor_agent.clone(
@@ -531,6 +637,12 @@ relationship_extractor_agent = base_instance_extractor_agent.clone(
     output_type=RelationshipInstanceBaseSchema,
 )
 
+relationship_instance_result_agent = create_result_agent(
+    base_agent=relationship_extractor_agent,
+    schema=RelationshipInstanceSchema,
+    item_description="relationship instance list",
+)
+
 # You can optionally create a list or dict to easily access all agents
 all_agents = {
     "domain_identifier": domain_identifier_agent,
@@ -540,24 +652,40 @@ all_agents = {
     "topic_identifier": topic_identifier_agent,
     "topic_result": topic_result_agent,
     "entity_type_identifier": entity_type_identifier_agent,
+    "entity_type_result": entity_type_result_agent,
     "ontology_type_identifier": ontology_type_identifier_agent,
+    "ontology_type_result": ontology_type_result_agent,
     "event_type_identifier": event_type_identifier_agent,
+    "event_type_result": event_type_result_agent,
     "statement_type_identifier": statement_type_identifier_agent,
+    "statement_type_result": statement_type_result_agent,
     "evidence_type_identifier": evidence_type_identifier_agent,
+    "evidence_type_result": evidence_type_result_agent,
     "measurement_type_identifier": measurement_type_identifier_agent,
+    "measurement_type_result": measurement_type_result_agent,
     "modality_type_identifier": modality_type_identifier_agent,
+    "modality_type_result": modality_type_result_agent,
     "entity_instance_extractor": entity_instance_extractor_agent,
+    "entity_instance_result": entity_instance_result_agent,
     "ontology_instance_extractor": ontology_instance_extractor_agent,
+    "ontology_instance_result": ontology_instance_result_agent,
     "event_instance_extractor": event_instance_extractor_agent,
+    "event_instance_result": event_instance_result_agent,
     "statement_instance_extractor": statement_instance_extractor_agent,
+    "statement_instance_result": statement_instance_result_agent,
     "evidence_instance_extractor": evidence_instance_extractor_agent,
+    "evidence_instance_result": evidence_instance_result_agent,
     "measurement_instance_extractor": measurement_instance_extractor_agent,
+    "measurement_instance_result": measurement_instance_result_agent,
     "modality_instance_extractor": modality_instance_extractor_agent,
+    "modality_instance_result": modality_instance_result_agent,
     "confidence_score": confidence_score_agent,
     "relevance_score": relevance_score_agent,
     "clarity_score": clarity_score_agent,
     "relationship_identifier": relationship_type_identifier_agent,
+    "relationship_result": relationship_result_agent,
     "relationship_instance_extractor": relationship_extractor_agent,
+    "relationship_instance_result": relationship_instance_result_agent,
     # Note: Base agent is not typically included here unless used directly
 }
 
@@ -566,3 +694,19 @@ if "__all__" in globals():
     __all_list.append("domain_result_agent")
     __all_list.append("sub_domain_result_agent")
     __all_list.append("topic_result_agent")
+    __all_list.append("entity_type_result_agent")
+    __all_list.append("ontology_type_result_agent")
+    __all_list.append("event_type_result_agent")
+    __all_list.append("statement_type_result_agent")
+    __all_list.append("evidence_type_result_agent")
+    __all_list.append("measurement_type_result_agent")
+    __all_list.append("modality_type_result_agent")
+    __all_list.append("entity_instance_result_agent")
+    __all_list.append("ontology_instance_result_agent")
+    __all_list.append("event_instance_result_agent")
+    __all_list.append("statement_instance_result_agent")
+    __all_list.append("evidence_instance_result_agent")
+    __all_list.append("measurement_instance_result_agent")
+    __all_list.append("modality_instance_result_agent")
+    __all_list.append("relationship_result_agent")
+    __all_list.append("relationship_instance_result_agent")


### PR DESCRIPTION
## Summary
- create new result agents for type, instance, and relationship steps
- expose these agents via `all_agents`
- invoke new result agents after scoring in each step

## Testing
- `ruff check .`
- `mypy .` *(fails: "RelationshipInstanceSchema" has no attribute errors)*