### PR TITLE
Add topic identifier schema

### DIFF
--- a/graphyte_ai/schemas.py
+++ b/graphyte_ai/schemas.py
@@ -130,6 +130,24 @@ class SubDomainSchema(BaseModel):
     )
 
 
+# --- New Schemas for Step 3 Topic Identifier Output ---
+
+
+class TopicIdentifierDetail(BaseModel):
+    """Represents a single identified topic without scores."""
+
+    topic: str = Field(description="The specific topic identified within the text.")
+
+
+class SingleSubDomainTopicIdentifierSchema(BaseModel):
+    """Schema defining unscored topic identification for one sub-domain."""
+
+    sub_domain: str = Field(description="The sub-domain being analyzed.")
+    identified_topics: List[TopicIdentifierDetail] = Field(
+        description="List of topics identified within the text relevant to this sub-domain."
+    )
+
+
 # Nested schema for a topic
 class TopicDetail(BaseModel):
     """Represents a single identified topic."""

--- a/graphyte_ai/workflow_agents.py
+++ b/graphyte_ai/workflow_agents.py
@@ -14,7 +14,7 @@ from .schemas import (
     DomainResultSchema,
     SubDomainIdentifierSchema,
     SubDomainSchema,
-    SingleSubDomainTopicSchema,
+    SingleSubDomainTopicIdentifierSchema,
     TopicSchema,
     EntityTypeSchema,
     OntologyTypeSchema,
@@ -211,14 +211,14 @@ topic_identifier_agent = Agent(
     name="TopicIdentifierAgent",
     instructions=(
         "You are provided with text, its primary domain, and ONE specific sub-domain. "
-        "Your task: Analyze the *full text* and identify specific, relevant topics mentioned within the text that fall under the provided single sub-domain. "
-        "Call the confidence_score, relevance_score, and clarity_score tools for each identified topic before producing the final output.\n"
-        "Output the results ONLY using the provided SingleSubDomainTopicSchema. Every item in identified_topics MUST include the topic string plus 'confidence_score', 'relevance_score', and 'clarity_score'."
+        "Analyze the *full text* and identify specific, relevant topics mentioned that fall under this sub-domain. "
+        "Do NOT call any scoring tools.\n"
+        "Return ONLY valid JSON using the SingleSubDomainTopicIdentifierSchema."
     ),
     model=TOPIC_MODEL,
     tools=[],
     handoffs=[],
-    output_type=SingleSubDomainTopicSchema,
+    output_type=SingleSubDomainTopicIdentifierSchema,
 )
 
 # --- Agent 3b: Topic Result ---


### PR DESCRIPTION
## Summary
- introduce `TopicIdentifierDetail` and `SingleSubDomainTopicIdentifierSchema`
- update `topic_identifier_agent` to output the new schema
- adapt Step 3 logic to handle the identifier schema

## Testing
- `black . --quiet`
- `ruff check .`
- `mypy .`
