### PR TITLE
Add per-subdomain trace IDs for step3

### DIFF
--- a/graphyte_ai/steps/step3_topics.py
+++ b/graphyte_ai/steps/step3_topics.py
@@ -7,7 +7,12 @@ from typing import List, Optional
 
 from pydantic import ValidationError
 
-from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
+from agents import (
+    RunConfig,
+    RunResult,
+    TResponseInputItem,
+    gen_trace_id,
+)  # type: ignore[attr-defined]
 
 from ..workflow_agents import topic_identifier_agent, topic_result_agent
 from ..config import TOPIC_MODEL, TOPIC_OUTPUT_DIR, TOPIC_OUTPUT_FILENAME
@@ -88,6 +93,7 @@ async def identify_topics(
             if len(current_sub_domain) > 28
             else current_sub_domain
         )
+        iter_trace_id = gen_trace_id()
         step3_iter_metadata_for_trace = {
             "workflow_step": f"3_topic_id_batch_{index+1}",
             "agent_name": f"Topic ID ({display_sub_domain})",
@@ -98,8 +104,8 @@ async def identify_topics(
             "batch_size": str(len(sub_domains_list_for_step3)),
         }
         step3_iter_run_config = RunConfig(
-            workflow_name="step3_topics",
-            trace_id=trace_id,
+            workflow_name=f"step3_topics:{display_sub_domain}",
+            trace_id=iter_trace_id,
             group_id=group_id,
             trace_metadata={
                 k: str(v) for k, v in step3_iter_metadata_for_trace.items()


### PR DESCRIPTION
## Summary
- generate a fresh trace ID for each subdomain iteration in step3
- include subdomain name in workflow names

## Testing
- `black graphyte_ai/steps/step3_topics.py`
- `ruff check .`
- `mypy .`
