### PR TITLE
feat: include trace info in scoring

### DIFF
--- a/graphyte_ai/steps/step3_topics.py
+++ b/graphyte_ai/steps/step3_topics.py
@@ -317,7 +317,7 @@ async def identify_topics(
         analysis_summary=f"Generated topics in parallel for {len(aggregated_topic_results)} sub-domains (out of {len(sub_domains_being_processed)} attempted).",  # Use processed count
     )
 
-    final_topic_data = await score_topics(final_topic_data, content)
+    final_topic_data = await score_topics(final_topic_data, content, group_id)
 
     scored_result = await run_agent_with_retry(
         topic_result_agent,


### PR DESCRIPTION
## Summary
- add custom span and RunConfig details for scoring
- pass group_id and metadata through scoring utilities
- link Step3 topic scoring to overall trace group

## Testing
- `black .`
- `ruff check .`
- `mypy .`
