### PR TITLE
Add tracing spans for step3 topic identification

### DIFF
--- a/graphyte_ai/steps/step3_topics.py
+++ b/graphyte_ai/steps/step3_topics.py
@@ -7,7 +7,13 @@ from typing import List, Optional
 
 from pydantic import ValidationError
 
-from agents import RunConfig, RunResult, TResponseInputItem  # type: ignore[attr-defined]
+from agents import (
+    RunConfig,
+    RunResult,
+    TResponseInputItem,
+    custom_span,
+    gen_trace_id,
+)  # type: ignore[attr-defined]
 
 from ..workflow_agents import topic_identifier_agent, topic_result_agent
 from ..config import TOPIC_MODEL, TOPIC_OUTPUT_DIR, TOPIC_OUTPUT_FILENAME
@@ -71,6 +77,27 @@ async def identify_topics(
     )  # Keep track of which sub-domain corresponds to which task/result
     aggregated_topic_results: List[SingleSubDomainTopicSchema] = []
 
+    async def _topic_task(
+        sub_domain: str,
+        input_list: List[TResponseInputItem],
+        metadata: dict[str, str],
+    ) -> RunResult:
+        """Run topic identification for a single sub-domain within its own span."""
+
+        step3_iter_trace_id = gen_trace_id()
+        step3_iter_run_config = RunConfig(
+            workflow_name="step3_topics",
+            trace_id=step3_iter_trace_id,
+            group_id=group_id,
+            trace_metadata={k: str(v) for k, v in metadata.items()},
+        )
+        with custom_span(f"Step3 topic ID: {sub_domain}"):
+            return await run_agent_with_retry(
+                agent=topic_identifier_agent,
+                input_data=input_list,
+                config=step3_iter_run_config,
+            )
+
     # --- Prepare tasks for parallel execution ---
     for index, current_sub_domain in enumerate(sub_domains_list_for_step3):
         if not current_sub_domain:  # Should have been filtered, but double-check
@@ -97,15 +124,6 @@ async def identify_topics(
             "batch_index": str(index + 1),
             "batch_size": str(len(sub_domains_list_for_step3)),
         }
-        step3_iter_run_config = RunConfig(
-            workflow_name="step3_topics",
-            trace_id=trace_id,
-            group_id=group_id,
-            trace_metadata={
-                k: str(v) for k, v in step3_iter_metadata_for_trace.items()
-            },
-        )
-
         step3_iter_input_list: List[TResponseInputItem] = [
             {
                 "role": "user",
@@ -117,14 +135,14 @@ async def identify_topics(
             },
         ]
 
-        # Create the async task using the retry wrapper
+        # Create the async task using the retry wrapper within its own span
         task = asyncio.create_task(
-            run_agent_with_retry(
-                agent=topic_identifier_agent,
-                input_data=step3_iter_input_list,
-                config=step3_iter_run_config,
+            _topic_task(
+                current_sub_domain,
+                step3_iter_input_list,
+                step3_iter_metadata_for_trace,
             ),
-            name=f"TopicTask_{current_sub_domain[:20]}",  # Optional: name task for debugging
+            name=f"TopicTask_{current_sub_domain[:20]}",
         )
         topic_tasks.append(task)
         sub_domains_being_processed.append(
@@ -299,11 +317,20 @@ async def identify_topics(
         analysis_summary=f"Generated topics in parallel for {len(aggregated_topic_results)} sub-domains (out of {len(sub_domains_being_processed)} attempted).",  # Use processed count
     )
 
-    final_topic_data = await score_topics(final_topic_data, content)
+    with custom_span("Step3 topic scoring"):
+        final_topic_data = await score_topics(final_topic_data, content)
 
+    step3_score_trace_id = gen_trace_id()
+    score_run_config = RunConfig(
+        workflow_name="step3_topics_scoring",
+        trace_id=step3_score_trace_id,
+        group_id=group_id,
+        trace_metadata={"workflow_step": "3_topic_scoring"},
+    )
     scored_result = await run_agent_with_retry(
         topic_result_agent,
         final_topic_data.model_dump_json(),
+        config=score_run_config,
     )
 
     if scored_result:


### PR DESCRIPTION
## Summary
- wrap topic identification calls in their own `custom_span`
- add per-subdomain tracing IDs for topic tasks
- trace scoring phase in step3 with a dedicated span

## Testing
- `black graphyte_ai/steps/step3_topics.py`
- `ruff check .`
- `mypy .`
